### PR TITLE
Fix nested empty arrays deserialization

### DIFF
--- a/spec/deserialize_function_spec.ts
+++ b/spec/deserialize_function_spec.ts
@@ -45,8 +45,8 @@ class Fruit {
 
 class Tree {
     @deserialize public value: string;
-    @deserializeAs(Array) fruits: Array<Fruit>;
-    @deserializeAs(Array) trees: Array<Tree>;
+    @deserializeAs(Fruit) fruits: Array<Fruit>;
+    @deserializeAs(Tree) trees: Array<Tree>;
 }
 
 var DeserializerFn = function(src : any) : any {
@@ -231,7 +231,6 @@ describe('Deserialize', function () {
         };
 
         var deserialized1 = Deserialize(root1, Tree);
-        console.log(deserialized1);
         expect(deserialized1.trees.length).toBe(0);
         expect(deserialized1.value).toBe("root1");
         expect(deserialized1.fruits.length).toBe(0);
@@ -264,7 +263,6 @@ describe('Deserialize', function () {
         };
 
         var deserialized2 = Deserialize(root2, Tree);
-        console.log(JSON.stringify(deserialized2));
         expect(deserialized2.trees.length).toBe(2);
         expect(deserialized2.trees[0].trees.length).toBe(0); /* t1 includes empty trees */
         expect(deserialized2.trees[0].fruits.length).toBe(0); /* t1 includes empty fruits */

--- a/spec/deserialize_function_spec.ts
+++ b/spec/deserialize_function_spec.ts
@@ -39,8 +39,13 @@ class JsonTest {
     }
 }
 
+class Fruit {
+    @deserialize public name: string;
+}
+
 class Tree {
     @deserialize public value: string;
+    @deserializeAs(Array) fruits: Array<Fruit>;
     @deserializeAs(Array) trees: Array<Tree>;
 }
 
@@ -177,7 +182,7 @@ describe('Deserialize', function () {
         expect(result.x).toBe("custom!");
     });
 
-    it('should parse a nested json including empty arrays', function() {
+    it('should deserialize a json including nested empty arrays', function() {
         var root1 = {
             trees: new Array<Tree>(),
             value: "root1"
@@ -213,9 +218,60 @@ describe('Deserialize', function () {
         };
 
         var deserialized2 = Deserialize(root2, Tree);
-        console.log(deserialized2);
         expect(deserialized2.trees.length).toBe(2);
-        expect(deserialized2.trees[0].trees.length).toBe(0); /* t1 includes an empty trees */
+        expect(deserialized2.trees[0].trees.length).toBe(0); /* t1 includes empty trees */
         expect(deserialized2.trees[1].trees.length).toBe(2); /* t2 includes 2 trees (t3, t4) */
+    });
+
+    it('should deserialize a json including nested, multiple empty arrays', function() {
+        var root1 = {
+            fruits: new Array<Fruit>(),
+            trees: new Array<Tree>(),
+            value: "root1"
+        };
+
+        var deserialized1 = Deserialize(root1, Tree);
+        console.log(deserialized1);
+        expect(deserialized1.trees.length).toBe(0);
+        expect(deserialized1.value).toBe("root1");
+        expect(deserialized1.fruits.length).toBe(0);
+
+        /**
+         * `-- root
+         *     |-- t1 including f1
+         *     `-- t2
+         *         |-- t3 including f3
+         *         `-- t4
+         */
+
+        var root2 = {
+            trees: [{
+                value: "t1" ,
+                trees: new Array<Tree>(),
+                fruits: new Array<Fruit>(),
+            }, {
+                value: "t2",
+                trees: [{
+                    value: "t3",
+                    trees: new Array<Tree>(),
+                    fruits: new Array<Fruit>(),
+                }, {
+                    value: "t4",
+                    trees: new Array<Tree>()
+                }]
+            }],
+            value: "root2"
+        };
+
+        var deserialized2 = Deserialize(root2, Tree);
+        console.log(JSON.stringify(deserialized2));
+        expect(deserialized2.trees.length).toBe(2);
+        expect(deserialized2.trees[0].trees.length).toBe(0); /* t1 includes empty trees */
+        expect(deserialized2.trees[0].fruits.length).toBe(0); /* t1 includes empty fruits */
+        expect(deserialized2.trees[1].trees.length).toBe(2); /* t2 includes 2 trees (t3, t4) */
+        expect(deserialized2.trees[1].trees[0].trees.length).toBe(0); /* t3 includes empty trees */
+        expect(deserialized2.trees[1].trees[0].fruits.length).toBe(0); /* t3 includes fruits trees */
+        expect(deserialized2.trees[1].trees[1].trees.length).toBe(0); /* t4 includes empty trees */
+        expect(deserialized2.trees[1].trees[1].fruits).toBeUndefined(); /* t4 has no fruits */
     });
 });

--- a/spec/deserialize_function_spec.ts
+++ b/spec/deserialize_function_spec.ts
@@ -39,6 +39,11 @@ class JsonTest {
     }
 }
 
+class Tree {
+    @deserialize public value: string;
+    @deserializeAs(Array) trees: Array<Tree>;
+}
+
 var DeserializerFn = function(src : any) : any {
     return 'custom!';
 };
@@ -170,5 +175,47 @@ describe('Deserialize', function () {
         };
         var result = Deserialize(testJson, CustomDeserializeTest2);
         expect(result.x).toBe("custom!");
+    });
+
+    it('should parse a nested json including empty arrays', function() {
+        var root1 = {
+            trees: new Array<Tree>(),
+            value: "root1"
+        };
+
+        var deserialized1 = Deserialize(root1, Tree);
+        expect(deserialized1.trees.length).toBe(0);
+        expect(deserialized1.value).toBe("root1");
+
+        /**
+         * `-- root
+         *     |-- t1
+         *     `-- t2
+         *         |-- t3
+         *         `-- t4
+         */
+
+        var root2 = {
+            trees: [{
+                value: "t1" ,
+                trees: new Array<Tree>()
+            }, {
+                value: "t2",
+                trees: [{
+                    value: "t3",
+                    trees: new Array<Tree>()
+                }, {
+                    value: "t4",
+                    trees: new Array<Tree>()
+                }]
+            }],
+            value: "root2"
+        };
+
+        var deserialized2 = Deserialize(root2, Tree);
+        console.log(deserialized2);
+        expect(deserialized2.trees.length).toBe(2);
+        expect(deserialized2.trees[0].trees.length).toBe(0); /* t1 includes an empty trees */
+        expect(deserialized2.trees[1].trees.length).toBe(2); /* t2 includes 2 trees (t3, t4) */
     });
 });

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -434,7 +434,11 @@ function deserializeObject(json : any, type : Function|ISerializable) : any {
 
         if (Array.isArray(source)) {
             if (source.length === 0) instance[metadata.keyName] = source;
-            else instance[metadata.keyName] = deserializeArray(source, type);
+            else {
+                if (typeof metadata.deserializedType === "function")
+                    type = metadata.deserializedType;
+                instance[metadata.keyName] = deserializeArray(source, type);
+            }
         }
         else if (metadata.deserializedType
           && typeof (<any>metadata.deserializedType).Deserialize === "function") {

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -432,11 +432,13 @@ function deserializeObject(json : any, type : Function|ISerializable) : any {
 
         if (source === void 0) continue;
 
-        if (metadata.deserializedType && typeof (<any>metadata.deserializedType).Deserialize === "function") {
-            instance[metadata.keyName] = (<any>metadata.deserializedType).Deserialize(source);
+        if (Array.isArray(source)) {
+            if (source.length === 0) instance[metadata.keyName] = source;
+            else instance[metadata.keyName] = deserializeArray(source, type);
         }
-        else if (Array.isArray(source)) {
-            instance[metadata.keyName] = deserializeArray(source, metadata.deserializedType);
+        else if (metadata.deserializedType
+          && typeof (<any>metadata.deserializedType).Deserialize === "function") {
+            instance[metadata.keyName] = (<any>metadata.deserializedType).Deserialize(source);
         }
         else if (typeof source === "string" && metadata.deserializedType === Date) {
             instance[metadata.keyName] = new Date(source);


### PR DESCRIPTION
I fixed Deserialize function for **nested, multiple empty arrays**. For example,

```typescript
// spec
class Tree  {
  @deserialize public value: string;
  @deserializeAs(Array) trees: Array<Tree>;
}

var root = {
  trees: [{
    value: "t1" ,
    trees: new Array<Tree>()
  }, {
    value: "t2",
    trees: [{
      value: "t3",
      trees: new Array<Tree>()
    }, {
      value: "t4",
      trees: new Array<Tree>()
    }]
  }],
  value: "root"
};

var deserialized = cerialize.Deserialize(root, Tree);
```

previous implementation throws an error like

```typescript
// error

    return new type(); //todo this probably wrong
               ^
TypeError: type is not a function
    at deserializeObject (..../node_modules/cerialize/dist/serialize.js:363:16)
    at Deserialize (..../node_modules/cerialize/dist/serialize.js:410:16)
    at deserializeArray (..../node_modules/cerialize/dist/serialize.js:351:19)
    at deserializeObject (..../node_modules/cerialize/dist/serialize.js:381:42)
    at Object.Deserialize (..../node_modules/cerialize/dist/serialize.js:410:16)
```

This PR deserializes successfully the above case. I also add 2 new tests (passed 71/72) 

But the problem is, It can't deserialize pseudo implemented `Set` since `Set` was implemented using `Array` (**This is the 1 failure test case**) in [autoserialization_annotation_spec.ts](https://github.com/weichx/cerialize/blob/87fe32f40e29abb97055e8f6b79be13fc73c597c/spec/autoserialize_annotation_spec.ts#L76) like

```typescript
/* [Weichx 12/9/15] credit to @garkin for contributing the rest of this file */
// ES6 Set stub
// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set
// https://github.com/cloud9ide/typescript/blob/master/typings/lib.d.ts
interface Set<T> {
    add(value : T): Set<T>;
    clear(): void;
    delete(value : T): boolean;
    forEach(callbackfn : (value : T, index : T, set : Set<T>) => void, thisArg? : any): void;
    has(value : T): boolean;
    size: number;
}
declare var Set : {
    new <T>(data? : T[]): Set<T>;
};

module Utility {
    export function unpackSet<T>(_set : Set<T>) : T[] {
        const result : T[] = [];
        _set.forEach(v => result.push(v));
        return result;
    }
}
```
