### PR TITLE
Fix: OnDeserialized in superclass is not called

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,11 @@ node_modules
 .idea
 *.iml
 
+spec/**/*.js
+spec/**/*.js.map
+src/**/*.js
+src/**/*.js.map
+
 spec/spec
 spec/src
 .gulp***

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 .idea
+*.iml
 
 spec/spec
 spec/src

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -371,21 +371,15 @@ function deserializeObjectInto(json : any, type : Function|ISerializable, instan
     }
 
     //invoke our after deserialized callback if provided
-    var ctorsWithOnDeserializedHook = new Array<any>();
     var ctor: any = type;
 
-    while(ctor && typeof (<any>ctor).OnDeserialized === "function") {
-        ctorsWithOnDeserializedHook.push(ctor);
+    // typeof (<any>ctor).OnDeserialized === "function") {
+    while(ctor) {
+        if (typeof (<any>ctor).OnDeserialized === "function") ctor.OnDeserialized(instance, json);
 
-        if (ctor.prototype &&
-          ctor.prototype.__proto__ &&
-          ctor.prototype.__proto__.constructor) { /** iff ctor has super class */
+        if (!(ctor.prototype && ctor.prototype.__proto__)) break; /* if ctor has no super class */
+
         ctor = ctor.prototype.__proto__.constructor;
-        }
-    }
-
-    for (var ctorIndex = 0; ctorIndex < ctorsWithOnDeserializedHook.length; ctorIndex++) {
-        ctorsWithOnDeserializedHook[ctorIndex].OnDeserialized(instance, json);
     }
 
     return instance;
@@ -468,21 +462,15 @@ function deserializeObject(json : any, type : Function|ISerializable) : any {
         }
     }
 
-    var ctorsWithOnDeserializedHook = new Array<any>();
     var ctor: any = type;
 
-    while(ctor && typeof (<any>ctor).OnDeserialized === "function") {
-        ctorsWithOnDeserializedHook.push(ctor);
+    // typeof (<any>ctor).OnDeserialized === "function") {
+    while(ctor) {
+        if (typeof (<any>ctor).OnDeserialized === "function") ctor.OnDeserialized(instance, json);
 
-        if (ctor.prototype &&
-          ctor.prototype.__proto__ &&
-          ctor.prototype.__proto__.constructor) { /** iff ctor has super class */
-           ctor = ctor.prototype.__proto__.constructor;
-        }
-    }
+        if (!(ctor.prototype && ctor.prototype.__proto__)) break; /* if ctor has no super class */
 
-    for (var ctorIndex = 0; ctorIndex < ctorsWithOnDeserializedHook.length; ctorIndex++) {
-        ctorsWithOnDeserializedHook[ctorIndex].OnDeserialized(instance, json);
+        ctor = ctor.prototype.__proto__.constructor;
     }
 
     return instance;

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -371,8 +371,21 @@ function deserializeObjectInto(json : any, type : Function|ISerializable, instan
     }
 
     //invoke our after deserialized callback if provided
-    if (type && typeof (<any>type).OnDeserialized === "function") {
-        (<any>type).OnDeserialized(instance, json);
+    var ctorsWithOnDeserializedHook = new Array<any>();
+    var ctor: any = type;
+
+    while(ctor && typeof (<any>ctor).OnDeserialized === "function") {
+        ctorsWithOnDeserializedHook.push(ctor);
+
+        if (ctor.prototype &&
+          ctor.prototype.__proto__ &&
+          ctor.prototype.__proto__.constructor) { /** iff ctor has super class */
+        ctor = ctor.prototype.__proto__.constructor;
+        }
+    }
+
+    for (var ctorIndex = 0; ctorIndex < ctorsWithOnDeserializedHook.length; ctorIndex++) {
+        ctorsWithOnDeserializedHook[ctorIndex].OnDeserialized(instance, json);
     }
 
     return instance;
@@ -455,8 +468,21 @@ function deserializeObject(json : any, type : Function|ISerializable) : any {
         }
     }
 
-    if (type && typeof (<any>type).OnDeserialized === "function") {
-        (<any>type).OnDeserialized(instance, json);
+    var ctorsWithOnDeserializedHook = new Array<any>();
+    var ctor: any = type;
+
+    while(ctor && typeof (<any>ctor).OnDeserialized === "function") {
+        ctorsWithOnDeserializedHook.push(ctor);
+
+        if (ctor.prototype &&
+          ctor.prototype.__proto__ &&
+          ctor.prototype.__proto__.constructor) { /** iff ctor has super class */
+           ctor = ctor.prototype.__proto__.constructor;
+        }
+    }
+
+    for (var ctorIndex = 0; ctorIndex < ctorsWithOnDeserializedHook.length; ctorIndex++) {
+        ctorsWithOnDeserializedHook[ctorIndex].OnDeserialized(instance, json);
     }
 
     return instance;

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -373,7 +373,6 @@ function deserializeObjectInto(json : any, type : Function|ISerializable, instan
     //invoke our after deserialized callback if provided
     var ctor: any = type;
 
-    // typeof (<any>ctor).OnDeserialized === "function") {
     while(ctor) {
         if (typeof (<any>ctor).OnDeserialized === "function") ctor.OnDeserialized(instance, json);
 
@@ -464,7 +463,6 @@ function deserializeObject(json : any, type : Function|ISerializable) : any {
 
     var ctor: any = type;
 
-    // typeof (<any>ctor).OnDeserialized === "function") {
     while(ctor) {
         if (typeof (<any>ctor).OnDeserialized === "function") ctor.OnDeserialized(instance, json);
 


### PR DESCRIPTION
Previous implementation doesn't call superclass's `OnDeserialized`. For example,

```typescript
class Person {
    @deserialize public name: string;
    @deserializeAs("_age") public age: string;
    public address: number;

    public static OnDeserialized(instance: Person, json: any): void {
        var address_info = json.address_info;

        if (address_info) {
            instance.address = address_info.home_address;
        }
    }
}

@inheritSerialization(Person)
class Student extends Person {
    @deserialize public school_name: string;
    @deserializeAs("class_number") public class: number;
    public GPA: number;

    public static OnDeserialized(instance: Student, json: any): void {
        var grades: Array<number> = json.grades;

        if (grades && Array.isArray(grades) && grades.length > 0) {
            var total: number = grades.reduce(function (acc, s) {
              return acc + s;
            }, 0);

            instance.GPA = total / grades.length;
        }
    }
}

// spec
it('should call OnDeserializes in the parent and child classes both', function() {
  var json = {
      name: "John Watson",
      _age: 23,
      address_info: {
          company_address: "BS-401",
          home_address: "Baker Street 221B"
      },

      school_name: "University of London",
      class_number: 15,
      grades: [90, 85, 77, 100]
  };

  var watson = Deserialize(json, Student);

  /** deserializing parent class variables */
  expect(watson.name).toEqual(json.name);
  expect(watson.age).toEqual(json._age);  
  expect(watson.address).toEqual(json.address_info.home_address); /* Failure because `OnDeserialize` in `Person` is not called */

  /** deserializing child class variables */
  expect(watson.school_name).toEqual(json.school_name); 
  expect(watson.class).toEqual(json.class_number);

  var expecteGPA = json.grades.reduce(function(acc, r) {
      return acc + r;
  }, 0) / json.grades.length;
  expect(watson.GPA).toEqual(expecteGPA);
});
```

So I fixed `OnDeserialized` logic (and also included test for it).

```typescript
// current PR implementation

var ctor: any = type;

while(ctor) {
    if (typeof (<any>ctor).OnDeserialized === "function") ctor.OnDeserialized(instance, json);

    if (!(ctor.prototype && ctor.prototype.__proto__)) break; /* if ctor has no super class */

    ctor = ctor.prototype.__proto__.constructor;
}
```

Previous implementations looks like,

```typescript
// previous
if (type && typeof (<any>type).OnDeserialized === "function") {
       (<any>type).OnDeserialized(instance, json);
}
```

If you don't mind I would like to extract the duplicatd `OnDeserialized` hook logic to **1** function. Since **they are the same and exists in two functions (`deserializedObject` and `deserializedObjectInto`)** And then, we could write tests for it instead of writing test for `deserializedObject` and `deserializedObjectInto`.