### PR TITLE
Indexables

### DIFF
--- a/dist/serialize.d.ts
+++ b/dist/serialize.d.ts
@@ -30,6 +30,7 @@ export declare function autoserialize(target: any, keyName: string): any;
 export declare function serializeAs(keyNameOrType: string | Serializer | ISerializable, keyName?: string): any;
 export declare function deserializeAs(keyNameOrType: string | Function | ISerializable, keyName?: string): any;
 export declare function autoserializeAs(keyNameOrType: string | Function | ISerializable, keyName?: string): any;
+export declare function autoserializeIndexable(type: Function | ISerializable, keyName?: string): any;
 export declare function DeserializeInto(source: any, type: Function | ISerializable, target: any): any;
 export declare function Deserialize(json: any, type?: Function | ISerializable): any;
 export declare function Serialize(instance: any): any;

--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/serialize');

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "author": "Matt Weichselbaum",
   "license": "MIT",
   "repository": "https://github.com/weichx/cerialize",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "main": "dist/serialize.js",
   "typings": "dist/serialize.d.ts",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "repository": "https://github.com/weichx/cerialize",
   "version": "0.1.5",
-  "main": "dist/serialize.js",
+  "main": "index.js",
   "typings": "dist/serialize.d.ts",
   "devDependencies": {
     "gulp": "^3.9.0",

--- a/spec/deserialize_function_spec.ts
+++ b/spec/deserialize_function_spec.ts
@@ -1,6 +1,7 @@
 ///<reference path="./typings/jasmine.d.ts"/>
 import {
-    __TypeMap, inheritSerialization, deserialize, deserializeAs, Deserialize, GenericDeserialize, GenericDeserializeInto
+    deserialize, deserializeAs, Deserialize, GenericDeserialize,
+    GenericDeserializeInto, deserializeIndexable
 } from '../src/serialize';
 
 class T1 {
@@ -274,6 +275,28 @@ describe('Deserialize', function () {
         expect(deserialized2.trees[1].trees[0].fruits.length).toBe(0); /* t3 includes fruits trees */
         expect(deserialized2.trees[1].trees[1].trees.length).toBe(0); /* t4 includes empty trees */
         expect(deserialized2.trees[1].trees[1].fruits).toBeUndefined(); /* t4 has no fruits */
+    });
+
+    it("Should deserialize indexable object", function () {
+
+        class Y {
+            @deserialize thing : string;
+        }
+
+        class X {
+            @deserializeIndexable(Y) yMap : any;
+        }
+
+        var map : any = {
+            yMap: {
+                1: { thing: '1' },
+                2: { thing: '2' }
+            }
+        };
+
+        var x : X = Deserialize(map, X);
+        expect(x.yMap[1] instanceof(Y)).toBe(true);
+        expect(x.yMap[2] instanceof(Y)).toBe(true);
     });
 
 });

--- a/spec/deserialize_into_spec.ts
+++ b/spec/deserialize_into_spec.ts
@@ -1,8 +1,8 @@
 ///<reference path="./typings/jasmine.d.ts"/>
-import { __TypeMap,
+import {
     deserialize,
     deserializeAs,
-    autoserialize,
+    deserializeIndexable,
     autoserializeAs,
     DeserializeInto
 } from '../src/serialize';
@@ -45,7 +45,8 @@ class JsonSubArrayTest {
 }
 
 class JSONSubObjectTest {
-    @deserialize public  obj : any;
+    @deserialize public obj : any;
+
     constructor() {
         this.obj = {
             subobject: {
@@ -201,7 +202,7 @@ describe('DeserializeInto', function () {
         var source = new JSONSubObjectTest();
         var originalSubObject = source.obj.subobject;
         expect(source.obj.subobject.c).toBeUndefined();
-        var json = { obj: { subobject: { a: 10 , b: 20, c: 30} } };
+        var json = { obj: { subobject: { a: 10, b: 20, c: 30 } } };
         var result = DeserializeInto(json, JSONSubObjectTest, source);
         expect(result).toEqual(source);
         expect(result.obj.subobject).toEqual(originalSubObject);
@@ -248,6 +249,35 @@ describe('DeserializeInto', function () {
         expect(result.children[1].x).toEqual("2");
         expect(result.children[2].x).toEqual("3");
         expect(result.children[3].x).toEqual("4");
+    });
+
+    it("Should deserialize indexable object", function () {
+
+        class Y {
+            @deserialize thing : string;
+        }
+
+        class X {
+            @deserializeIndexable(Y) yMap : any;
+
+            constructor() {
+                this.yMap = {};
+            }
+        }
+
+        var map : any = {
+            yMap: {
+                1: { thing: '1' },
+                2: { thing: '2' }
+            }
+        };
+
+        var x = new X();
+        var yMap = x.yMap;
+        DeserializeInto(map, X, x);
+        expect(x.yMap).toBe(yMap);
+        expect(x.yMap[1] instanceof (Y)).toBe(true);
+        expect(x.yMap[2] instanceof (Y)).toBe(true);
     });
 });
 

--- a/spec/key_transform_spec.ts
+++ b/spec/key_transform_spec.ts
@@ -25,6 +25,11 @@ class T1 {
 
 describe('Key Transforms', function () {
 
+    afterEach(function () {
+        DeserializeKeysFrom(CamelCase);
+        SerializeKeysTo(CamelCase);
+    });
+    
     it('should just clone key name if no transform functions are set', function() {
         SerializeKeysTo(null);
         DeserializeKeysFrom(null);
@@ -69,4 +74,5 @@ describe('Key Transforms', function () {
         expect(result.myVar).toBe(10);
         expect(result.other).toBe(11);
     });
+
 });

--- a/spec/serialize_function_spec.ts
+++ b/spec/serialize_function_spec.ts
@@ -1,5 +1,5 @@
 ///<reference path="./typings/jasmine.d.ts"/>
-import { __TypeMap, serialize, serializeAs, Serialize } from '../src/serialize';
+import {__TypeMap, serialize, serializeAs, Serialize, serializeIndexable} from '../src/serialize';
 
 class Vector3 {
     @serialize x : number;
@@ -177,4 +177,31 @@ describe('Serialize', function () {
         var result = Serialize(test);
         expect(result.x).toBe('custom!');
     });
+
+    it('should serialize indexable objects', function() {
+        class Y {
+
+            @serialize thing : string;
+
+            constructor(str : string) {
+                this.thing = str;
+            }
+
+        }
+        class X {
+            @serializeIndexable(Y) yMap : any;
+        }
+
+        var x = new X();
+
+        x.yMap = {
+            1: new Y('one'),
+            2: new Y('two')
+        };
+
+        var json : any = Serialize(x);
+        expect(json.yMap[1].thing).toBe('one');
+        expect(json.yMap[2].thing).toBe('two');
+    });
+
 });

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -161,6 +161,7 @@ export function serializeAs(keyNameOrType : string|Serializer|ISerializable, key
     };
 }
 
+//Supports serializing of dictionary-like map objects, ie: { x: {}, y: {} }
 export function serializeIndexable(type : Serializer|ISerializable, keyName? : string) : any {
     if (!type) return;
     return function (target : any, actualKeyName : string) : any {
@@ -200,6 +201,7 @@ export function deserializeAs(keyNameOrType : string|Function|ISerializable, key
     };
 }
 
+//Supports deserializing of dictionary-like map objects, ie: { x: {}, y: {} }
 export function deserializeIndexable(type : Function|ISerializable, keyName? : string) : any {
     if (!type) return;
     var key = keyName;
@@ -241,6 +243,7 @@ export function autoserializeAs(keyNameOrType : string|Function|ISerializable, k
     };
 }
 
+//Supports serializing/deserializing of dictionary-like map objects, ie: { x: {}, y: {} }
 export function autoserializeIndexable(type : Function|ISerializable, keyName? : string) : any {
     if (!type) return;
     var key = keyName;


### PR DESCRIPTION
Support serializing objects when used as a map type such as `{ x: {}, y: {} }`