### PR TITLE
Give a type to used in Serialize function

### DIFF
--- a/dist/serialize.d.ts
+++ b/dist/serialize.d.ts
@@ -35,7 +35,7 @@ export declare function autoserializeAs(keyNameOrType: string | Function | ISeri
 export declare function autoserializeIndexable(type: Function | ISerializable, keyName?: string): any;
 export declare function Deserialize(json: any, type?: Function | ISerializable): any;
 export declare function DeserializeInto(source: any, type: Function | ISerializable, target: any): any;
-export declare function Serialize(instance: any): any;
+export declare function Serialize(instance: any, type?: Function | ISerializable): any;
 export declare function GenericDeserialize<T>(json: any, type: new () => T): T;
 export declare function GenericDeserializeInto<T>(json: any, type: new () => T, instance: T): T;
 export declare function DeserializeKeysFrom(transform: (key: string) => string): void;

--- a/dist/serialize.js
+++ b/dist/serialize.js
@@ -1,3 +1,4 @@
+"use strict";
 var win = null;
 try {
     win = window;
@@ -281,7 +282,7 @@ var MetaData = (function () {
         return metadata;
     };
     return MetaData;
-})();
+}());
 //merges two primitive objects recursively, overwriting or defining properties on
 //`instance` as they defined in `json`. Works on objects, arrays and primitives
 function mergePrimitiveObjects(instance, json) {
@@ -534,17 +535,23 @@ function deserializeIndexableObjectInto(source, type, instance) {
     return instance;
 }
 //take an array and spit out json
-function serializeArray(source) {
+function serializeArray(source, type) {
     var serializedArray = new Array(source.length);
     for (var j = 0; j < source.length; j++) {
-        serializedArray[j] = Serialize(source[j]);
+        serializedArray[j] = Serialize(source[j], type);
     }
     return serializedArray;
 }
 //take an instance of something and try to spit out json for it based on property annotaitons
-function serializeTypedObject(instance) {
+function serializeTypedObject(instance, type) {
     var json = {};
-    var metadataArray = TypeMap.get(instance.constructor);
+    var metadataArray;
+    if (type) {
+        metadataArray = TypeMap.get(type);
+    }
+    else {
+        metadataArray = TypeMap.get(instance.constructor);
+    }
     for (var i = 0; i < metadataArray.length; i++) {
         var metadata = metadataArray[i];
         if (!metadata.serializedKey)
@@ -576,11 +583,14 @@ function serializeTypedObject(instance) {
     return json;
 }
 //take an instance of something and spit out some json
-function Serialize(instance) {
+function Serialize(instance, type) {
     if (instance === null || instance === void 0)
         return null;
     if (Array.isArray(instance)) {
-        return serializeArray(instance);
+        return serializeArray(instance, type);
+    }
+    if (type && TypeMap.has(type)) {
+        return serializeTypedObject(instance, type);
     }
     if (instance.constructor && TypeMap.has(instance.constructor)) {
         return serializeTypedObject(instance);

--- a/spec/serialize_function_spec.ts
+++ b/spec/serialize_function_spec.ts
@@ -127,6 +127,15 @@ describe('Serialize', function () {
         expect(serialized.z).toBe(void 0);
     });
 
+    it('should serialize object with the given type', function () {
+        var test = {x: 1, y: 2, z: 3};
+        var serialized = Serialize(test, Vector3);
+        expect((serialized instanceof Vector3)).toBe(false);
+        expect(serialized.x).toBe(test.x);
+        expect(serialized.y).toBe(test.y);
+        expect(serialized.z).toBe(void 0);
+    });
+
     it('should serialize a typed object with a typed array', function () {
         var test = new TArray(10, 11, [new Vector3(1, 2), new Vector3(2, 1)]);
         var serialized = Serialize(test);

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -596,20 +596,25 @@ function deserializeIndexableObjectInto(source : any, type : Function | ISeriali
 }
 
 //take an array and spit out json
-function serializeArray(source : Array<any>) : Array<any> {
+function serializeArray(source : Array<any>, type? : Function|ISerializable) : Array<any> {
     var serializedArray : Array<any> = new Array(source.length);
     for (var j = 0; j < source.length; j++) {
-        serializedArray[j] = Serialize(source[j]);
+        serializedArray[j] = Serialize(source[j], type);
     }
     return serializedArray;
 }
 
 //take an instance of something and try to spit out json for it based on property annotaitons
-function serializeTypedObject(instance : any) : any {
+function serializeTypedObject(instance : any, type? : Function|ISerializable) : any {
 
     var json : any = {};
 
-    var metadataArray : Array<MetaData> = TypeMap.get(instance.constructor);
+    var metadataArray : Array<MetaData>;
+    if (type) {
+        metadataArray = TypeMap.get(type);
+    } else {
+        metadataArray = TypeMap.get(instance.constructor);
+    }
 
     for (var i = 0; i < metadataArray.length; i++) {
         var metadata = metadataArray[i];
@@ -649,11 +654,15 @@ function serializeTypedObject(instance : any) : any {
 }
 
 //take an instance of something and spit out some json
-export function Serialize(instance : any) : any {
+export function Serialize(instance : any, type? : Function|ISerializable) : any {
     if (instance === null || instance === void 0) return null;
 
     if (Array.isArray(instance)) {
-        return serializeArray(instance);
+        return serializeArray(instance, type);
+    }
+
+    if (type && TypeMap.has(type)) {
+        return serializeTypedObject(instance, type);
     }
 
     if (instance.constructor && TypeMap.has(instance.constructor)) {


### PR DESCRIPTION
Add an optional parameter in Serialize function to specify the type which will be used to serialize the object.
See example (used in test):
```javascript
    it('should serialize object with the given type', function () {
        var test = {x: 1, y: 2, z: 3};
        var serialized = Serialize(test, Vector3);
        expect((serialized instanceof Vector3)).toBe(false);
        expect(serialized.x).toBe(test.x);
        expect(serialized.y).toBe(test.y);
        expect(serialized.z).toBe(void 0);
    });
```