### PR TITLE
Added new way to create object instances when deserializing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,8 @@ The `instantiationMethod` parameter can be used to change the way in which insta
 	Deserialize({value: 'example'}, Immutable, InstantiationMethod.None);         // Object {value: 'example'}
 ```
 
+The default InstantiationMethod can be changed with `SetDefaultInstantiationMethod(instantiationMethod : InstantiationMethod)`
+
 ##### Functions
 - `Deserialize<T>(json : JsonObject, ClassConstructor<T>, target? : T) : T`
     ```typescript

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ If you want the same behavior for a property when serializing and deserializing,
 ##### Types
 ```typescript
  type SerializationFn = <T>(target : T) => JsonType;
- type DeserializationFn = <T>(data : JsonType, target? : T, instantiationMethod? : boolean) => T
+ type DeserializationFn = <T>(data : JsonType, target? : T, instantiationMethod? : InstantiationMethod) => T
  type SerializeAndDeserializeFns = { 
      Serialize: SerializationFn,
      Deserialize: DeserializationFn
@@ -376,7 +376,7 @@ A callback can be provided for when a class is serialized. To define the callbac
 ```
 
 ## onDeserialized Callback
-A callback can be provided for when a class is deserialized. To define the callback, add a static method `onDeserialized<T>(instance : T, json : JsonObject, instantiationMethod = true)` to the class that needs custom post processing. You can either return a new value from this function, or modify the `json` parameter. The `instantiationMethod` parameter signifies whether the initial call to deserialize this object should create instances of the types (when true) or just plain objects (when false)
+A callback can be provided for when a class is deserialized. To define the callback, add a static method `onDeserialized<T>(instance : T, json : JsonObject, instantiationMethod = InstantationMethod.New)` to the class that needs custom post processing. You can either return a new value from this function, or modify the `json` parameter. The `instantiationMethod` parameter signifies whether the initial call to deserialize this object should create instances of the types (when true) or just plain objects (when false)
 
 ```typescript 
     class CrewMember {
@@ -384,7 +384,7 @@ A callback can be provided for when a class is deserialized. To define the callb
         @autoserializeAs(String) firstName;
         @autoserializeAs(String) lastName;
 
-        static onDeserialized(instance : CrewMember, json : JsonObject, instantiationMethod : Instances) {
+        static onDeserialized(instance : CrewMember, json : JsonObject, instantiationMethod : InstantiationMethod) {
             instance.firstName = json.firstName.toLowerCase();
             instance.lastName = json.lastName.toLowerCase();
         }

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Once you have annotated your class types, you can use the `Serialize*` and `Dese
         // when deserializing our planet log we need to convert the timezone 
         // of the timeVisited value from galactic to local time  
         // (This could also be done via @deserializeUsing(Time.toLocalTime))
-        static onDeserialized(instance : PlanetLog, json : JsonObject, createInstances : boolean) {
+        static onDeserialized(instance : PlanetLog, json : JsonObject, instantiationMethod : boolean) {
             instance.timeVisited = Time.toLocalTime(instance.timeVisited);
         }
 
@@ -168,7 +168,7 @@ If you want the same behavior for a property when serializing and deserializing,
 ##### Types
 ```typescript
  type SerializationFn = <T>(target : T) => JsonType;
- type DeserializationFn = <T>(data : JsonType, target? : T, createInstances? : boolean) => T
+ type DeserializationFn = <T>(data : JsonType, target? : T, instantiationMethod? : boolean) => T
  type SerializeAndDeserializeFns = { 
      Serialize: SerializationFn,
      Deserialize: DeserializationFn
@@ -230,7 +230,7 @@ It is also possible to re-use existing objects when deserializing with `Deserial
 
 #### Deserializing Into Plain Objects
 
-The `createInstances` parameter can be used to change the way in which instances of the input type are created. With `InstantiationMethod.New`, the constructor will be invoked when a new instance needs to be created. With `InstantiationMethod.ObjectCreate`, the object will be created without invoking its constructor, which is useful for systems where constructed objects immediately freeze themselves. With `InstantiationMethod.None`, the `deserializeXXX` functions will return a plain object instead, which can be useful for systems like Redux that expect / require plain objects and not class instances.
+The `instantiationMethod` parameter can be used to change the way in which instances of the input type are created. With `InstantiationMethod.New`, the constructor will be invoked when a new instance needs to be created. With `InstantiationMethod.ObjectCreate`, the object will be created without invoking its constructor, which is useful for systems where constructed objects immediately freeze themselves. With `InstantiationMethod.None`, the `deserializeXXX` functions will return a plain object instead, which can be useful for systems like Redux that expect / require plain objects and not class instances.
 
 ```typescript
 	import {Deserialize, Instances} from 'cerialize';
@@ -376,7 +376,7 @@ A callback can be provided for when a class is serialized. To define the callbac
 ```
 
 ## onDeserialized Callback
-A callback can be provided for when a class is deserialized. To define the callback, add a static method `onDeserialized<T>(instance : T, json : JsonObject, createInstances = true)` to the class that needs custom post processing. You can either return a new value from this function, or modify the `json` parameter. The `createInstances` parameter signifies whether the initial call to deserialize this object should create instances of the types (when true) or just plain objects (when false)
+A callback can be provided for when a class is deserialized. To define the callback, add a static method `onDeserialized<T>(instance : T, json : JsonObject, instantiationMethod = true)` to the class that needs custom post processing. You can either return a new value from this function, or modify the `json` parameter. The `instantiationMethod` parameter signifies whether the initial call to deserialize this object should create instances of the types (when true) or just plain objects (when false)
 
 ```typescript 
     class CrewMember {
@@ -384,7 +384,7 @@ A callback can be provided for when a class is deserialized. To define the callb
         @autoserializeAs(String) firstName;
         @autoserializeAs(String) lastName;
 
-        static onDeserialized(instance : CrewMember, json : JsonObject, createInstances : Instances) {
+        static onDeserialized(instance : CrewMember, json : JsonObject, instantiationMethod : Instances) {
             instance.firstName = json.firstName.toLowerCase();
             instance.lastName = json.lastName.toLowerCase();
         }

--- a/README.md
+++ b/README.md
@@ -230,7 +230,30 @@ It is also possible to re-use existing objects when deserializing with `Deserial
 
 #### Deserializing Into Plain Objects
 
-The `createInstances` parameter can be used to toggle between creating actual instances of the input type, or when false the `deserializeXXX` functions will return a plain object instead. This can be useful for systems like Redux which expect / require plain objects and not class instances. 
+The `createInstances` parameter can be used to change the way in which instances of the input type are created. With `Instances.Construct`, the constructor will be invoked when a new instance needs to be created. With `Instances.Create`, the object will be created without invoking its constructor, which is useful for systems where constructed objects immediately freeze themselves. With `Instances.Plain`, the `deserializeXXX` functions will return a plain object instead, which can be useful for systems like Redux that expect / require plain objects and not class instances.
+
+```typescript
+	import {Deserialize, Instances} from 'cerialize';
+	
+	class Immutable {
+	
+		public value : string;
+		
+		constructor(value : string) {
+			this.value = value;
+			Object.freeze(this);
+		}
+		
+		public getValue() : string {
+			return value;
+		}
+		
+	}
+	
+	Deserialize({value: 'example'}, Immutable, Instances.Construct); // Error because of Object.freeze
+	Deserialize({value: 'example'}, Immutable, Instances.Create);    // Immutable {value 'example'}
+	Deserialize({value: 'example'}, Immutable, Instances.Plain);     // Object {value: 'example'}
+```
 
 ##### Functions
 - `Deserialize<T>(json : JsonObject, ClassConstructor<T>, target? : T) : T`
@@ -361,7 +384,7 @@ A callback can be provided for when a class is deserialized. To define the callb
         @autoserializeAs(String) firstName;
         @autoserializeAs(String) lastName;
 
-        static onDeserialized(instance : CrewMember, json : JsonObject, createInstances : boolean) {
+        static onDeserialized(instance : CrewMember, json : JsonObject, createInstances : Instances) {
             instance.firstName = json.firstName.toLowerCase();
             instance.lastName = json.lastName.toLowerCase();
         }

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ It is also possible to re-use existing objects when deserializing with `Deserial
 
 #### Deserializing Into Plain Objects
 
-The `createInstances` parameter can be used to change the way in which instances of the input type are created. With `Instances.Construct`, the constructor will be invoked when a new instance needs to be created. With `Instances.Create`, the object will be created without invoking its constructor, which is useful for systems where constructed objects immediately freeze themselves. With `Instances.Plain`, the `deserializeXXX` functions will return a plain object instead, which can be useful for systems like Redux that expect / require plain objects and not class instances.
+The `createInstances` parameter can be used to change the way in which instances of the input type are created. With `InstantiationMethod.New`, the constructor will be invoked when a new instance needs to be created. With `InstantiationMethod.ObjectCreate`, the object will be created without invoking its constructor, which is useful for systems where constructed objects immediately freeze themselves. With `InstantiationMethod.None`, the `deserializeXXX` functions will return a plain object instead, which can be useful for systems like Redux that expect / require plain objects and not class instances.
 
 ```typescript
 	import {Deserialize, Instances} from 'cerialize';
@@ -250,9 +250,9 @@ The `createInstances` parameter can be used to change the way in which instances
 		
 	}
 	
-	Deserialize({value: 'example'}, Immutable, Instances.Construct); // Error because of Object.freeze
-	Deserialize({value: 'example'}, Immutable, Instances.Create);    // Immutable {value 'example'}
-	Deserialize({value: 'example'}, Immutable, Instances.Plain);     // Object {value: 'example'}
+	Deserialize({value: 'example'}, Immutable, InstantiationMethod.New);          // Error because of Object.freeze
+	Deserialize({value: 'example'}, Immutable, InstantiationMethod.ObjectCreate); // Immutable {value 'example'}
+	Deserialize({value: 'example'}, Immutable, InstantiationMethod.None);         // Object {value: 'example'}
 ```
 
 ##### Functions

--- a/spec/deserialize.spec.ts
+++ b/spec/deserialize.spec.ts
@@ -10,17 +10,17 @@ import {
     deserializeAsJson,
     deserializeAsMap,
     deserializeUsing, SetDeserializeKeyTransform
-} from "../src";
-import {Instances, Indexable, JsonObject} from "../src/util";
+}                                                   from "../src";
+import {InstantiationMethod, Indexable, JsonObject} from "../src/util";
 
-function expectInstance(instance : any, type : any, createInstances : Instances) {
+function expectInstance(instance : any, type : any, createInstances : InstantiationMethod) {
     switch (createInstances) {
-		case Instances.Construct:
-		case Instances.Create:
+		case InstantiationMethod.New:
+		case InstantiationMethod.ObjectCreate:
 			expect(instance instanceof type).toBe(true);
 			break;
 
-		case Instances.Plain:
+		case InstantiationMethod.None:
 			expect(instance instanceof type).toBeFalsy();
 			expect(instance.toString()).toBe("[object Object]");
 			break;
@@ -31,17 +31,17 @@ function expectTarget(target : any, instance : any, shouldMakeTarget : boolean) 
     expect(instance === target).toBe(shouldMakeTarget);
 }
 
-function createTarget(shouldMakeTarget : boolean, shouldCreateInstances : Instances, type : any) {
+function createTarget(shouldMakeTarget : boolean, shouldCreateInstances : InstantiationMethod, type : any) {
     if (!shouldMakeTarget) return null;
 
     switch (shouldCreateInstances) {
-        case Instances.Construct:
+        case InstantiationMethod.New:
             return new type();
 
-        case Instances.Create:
+        case InstantiationMethod.ObjectCreate:
             return Object.create(type.prototype);
 
-        case Instances.Plain:
+        case InstantiationMethod.None:
             return {};
     }
 }
@@ -66,7 +66,7 @@ describe("Deserializing", function () {
 
     describe("DeserializeAs", function () {
 
-        function runTests(blockName : string, createInstances : Instances, deserializeAs : any, makeTarget : boolean) {
+        function runTests(blockName : string, createInstances : InstantiationMethod, deserializeAs : any, makeTarget : boolean) {
 
             describe(blockName, function () {
 
@@ -294,20 +294,20 @@ describe("Deserializing", function () {
 
         }
 
-        runTests("Normal > Create Instances > With Target", Instances.Construct, deserializeAs, true);
-        runTests("Normal > Create Instances > Without Target", Instances.Construct, deserializeAs, false);
-        runTests("Normal > No Instances > With Target", Instances.Plain, deserializeAs, true);
-        runTests("Normal > No Instances > Without Target", Instances.Plain, deserializeAs, false);
-        runTests("Auto > Create Instances > With Target", Instances.Construct, autoserializeAs, true);
-        runTests("Auto > Create Instances > Without Target", Instances.Construct, autoserializeAs, false);
-        runTests("Auto > No Instances > With Target", Instances.Plain, autoserializeAs, true);
-        runTests("Auto > No Instances > Without Target", Instances.Plain, autoserializeAs, false);
+        runTests("Normal > Create Instances > With Target", InstantiationMethod.New, deserializeAs, true);
+        runTests("Normal > Create Instances > Without Target", InstantiationMethod.New, deserializeAs, false);
+        runTests("Normal > No Instances > With Target", InstantiationMethod.None, deserializeAs, true);
+        runTests("Normal > No Instances > Without Target", InstantiationMethod.None, deserializeAs, false);
+        runTests("Auto > Create Instances > With Target", InstantiationMethod.New, autoserializeAs, true);
+        runTests("Auto > Create Instances > Without Target", InstantiationMethod.New, autoserializeAs, false);
+        runTests("Auto > No Instances > With Target", InstantiationMethod.None, autoserializeAs, true);
+        runTests("Auto > No Instances > Without Target", InstantiationMethod.None, autoserializeAs, false);
 
     });
 
     describe("DeserializeAsMap", function () {
 
-        function runTests(blockName : string, createInstances : Instances, deserializeAs : any, deserializeAsMap : any, makeTarget : boolean) {
+        function runTests(blockName : string, createInstances : InstantiationMethod, deserializeAs : any, deserializeAsMap : any, makeTarget : boolean) {
 
             describe(blockName, function () {
 
@@ -471,20 +471,20 @@ describe("Deserializing", function () {
 
         }
 
-        runTests("Normal > Create Instances > With Target", Instances.Construct, deserializeAs, deserializeAsMap, true);
-        runTests("Normal > Create Instances > Without Target", Instances.Construct, deserializeAs, deserializeAsMap, false);
-        runTests("Normal > No Instances > With Target", Instances.Plain, deserializeAs, deserializeAsMap, true);
-        runTests("Normal > No Instances > Without Target", Instances.Plain, deserializeAs, deserializeAsMap, false);
-        runTests("Auto > Create Instances > With Target", Instances.Construct, autoserializeAs, autoserializeAsMap, true);
-        runTests("Auto > Create Instances > Without Target", Instances.Construct, autoserializeAs, autoserializeAsMap, false);
-        runTests("Auto > No Instances > With Target", Instances.Plain, autoserializeAs, autoserializeAsMap, true);
-        runTests("Auto > No Instances > Without Target", Instances.Plain, autoserializeAs, autoserializeAsMap, false);
+        runTests("Normal > Create Instances > With Target", InstantiationMethod.New, deserializeAs, deserializeAsMap, true);
+        runTests("Normal > Create Instances > Without Target", InstantiationMethod.New, deserializeAs, deserializeAsMap, false);
+        runTests("Normal > No Instances > With Target", InstantiationMethod.None, deserializeAs, deserializeAsMap, true);
+        runTests("Normal > No Instances > Without Target", InstantiationMethod.None, deserializeAs, deserializeAsMap, false);
+        runTests("Auto > Create Instances > With Target", InstantiationMethod.New, autoserializeAs, autoserializeAsMap, true);
+        runTests("Auto > Create Instances > Without Target", InstantiationMethod.New, autoserializeAs, autoserializeAsMap, false);
+        runTests("Auto > No Instances > With Target", InstantiationMethod.None, autoserializeAs, autoserializeAsMap, true);
+        runTests("Auto > No Instances > Without Target", InstantiationMethod.None, autoserializeAs, autoserializeAsMap, false);
 
     });
 
     describe("DeserializeAsArray", function () {
 
-        function runTests(blockName : string, createInstances : Instances, deserializeAs : any, deserializeAsArray : any, makeTarget : boolean) {
+        function runTests(blockName : string, createInstances : InstantiationMethod, deserializeAs : any, deserializeAsArray : any, makeTarget : boolean) {
 
             describe(blockName, function () {
 
@@ -641,20 +641,20 @@ describe("Deserializing", function () {
 
         }
 
-        runTests("Normal > Create Instances > With Target", Instances.Construct, deserializeAs, deserializeAsArray, true);
-        runTests("Normal > Create Instances > Without Target", Instances.Construct, deserializeAs, deserializeAsArray, false);
-        runTests("Normal > No Instances > With Target", Instances.Plain, deserializeAs, deserializeAsArray, true);
-        runTests("Normal > No Instances > Without Target", Instances.Plain, deserializeAs, deserializeAsArray, false);
-        runTests("Auto > Create Instances > With Target", Instances.Construct, autoserializeAs, autoserializeAsArray, true);
-        runTests("Auto > Create Instances > Without Target", Instances.Construct, autoserializeAs, autoserializeAsArray, false);
-        runTests("Auto > No Instances > With Target", Instances.Plain, autoserializeAs, autoserializeAsArray, true);
-        runTests("Auto > No Instances > Without Target", Instances.Plain, autoserializeAs, autoserializeAsArray, false);
+        runTests("Normal > Create Instances > With Target", InstantiationMethod.New, deserializeAs, deserializeAsArray, true);
+        runTests("Normal > Create Instances > Without Target", InstantiationMethod.New, deserializeAs, deserializeAsArray, false);
+        runTests("Normal > No Instances > With Target", InstantiationMethod.None, deserializeAs, deserializeAsArray, true);
+        runTests("Normal > No Instances > Without Target", InstantiationMethod.None, deserializeAs, deserializeAsArray, false);
+        runTests("Auto > Create Instances > With Target", InstantiationMethod.New, autoserializeAs, autoserializeAsArray, true);
+        runTests("Auto > Create Instances > Without Target", InstantiationMethod.New, autoserializeAs, autoserializeAsArray, false);
+        runTests("Auto > No Instances > With Target", InstantiationMethod.None, autoserializeAs, autoserializeAsArray, true);
+        runTests("Auto > No Instances > Without Target", InstantiationMethod.None, autoserializeAs, autoserializeAsArray, false);
 
     });
 
     describe("DeserializeJSON", function () {
 
-        function runTests(blockName : string, createInstances : Instances, deserializeAs : any, deserializeAsJson : any, makeTarget : boolean) {
+        function runTests(blockName : string, createInstances : InstantiationMethod, deserializeAs : any, deserializeAsJson : any, makeTarget : boolean) {
 
             describe(blockName, function () {
 
@@ -919,20 +919,20 @@ describe("Deserializing", function () {
             });
         }
 
-        runTests("Normal > Create Instances > With Target", Instances.Construct, deserializeAs, deserializeAsJson, true);
-        runTests("Normal > Create Instances > Without Target", Instances.Construct, deserializeAs, deserializeAsJson, false);
-        runTests("Normal > No Instances > With Target", Instances.Plain, deserializeAs, deserializeAsJson, true);
-        runTests("Normal > No Instances > Without Target", Instances.Plain, deserializeAs, deserializeAsJson, false);
-        runTests("Auto > Create Instances > With Target", Instances.Construct, autoserializeAs, autoserializeAsJson, true);
-        runTests("Auto > Create Instances > Without Target", Instances.Construct, autoserializeAs, autoserializeAsJson, false);
-        runTests("Auto > No Instances > With Target", Instances.Plain, autoserializeAs, autoserializeAsJson, true);
-        runTests("Auto > No Instances > Without Target", Instances.Plain, autoserializeAs, autoserializeAsJson, false);
+        runTests("Normal > Create Instances > With Target", InstantiationMethod.New, deserializeAs, deserializeAsJson, true);
+        runTests("Normal > Create Instances > Without Target", InstantiationMethod.New, deserializeAs, deserializeAsJson, false);
+        runTests("Normal > No Instances > With Target", InstantiationMethod.None, deserializeAs, deserializeAsJson, true);
+        runTests("Normal > No Instances > Without Target", InstantiationMethod.None, deserializeAs, deserializeAsJson, false);
+        runTests("Auto > Create Instances > With Target", InstantiationMethod.New, autoserializeAs, autoserializeAsJson, true);
+        runTests("Auto > Create Instances > Without Target", InstantiationMethod.New, autoserializeAs, autoserializeAsJson, false);
+        runTests("Auto > No Instances > With Target", InstantiationMethod.None, autoserializeAs, autoserializeAsJson, true);
+        runTests("Auto > No Instances > Without Target", InstantiationMethod.None, autoserializeAs, autoserializeAsJson, false);
 
     });
 
     describe("DeserializeUsing", function () {
 
-        function runTests(blockName : string, createInstances : Instances, deserializeAs : any, deserializeUsing : any, makeTarget : boolean) {
+        function runTests(blockName : string, createInstances : InstantiationMethod, deserializeAs : any, deserializeUsing : any, makeTarget : boolean) {
 
             it("uses the provided function", function () {
                 function x(value : any) { return 1; }
@@ -957,10 +957,10 @@ describe("Deserializing", function () {
 
         }
 
-        runTests("Normal > Create Instances > With Target", Instances.Construct, deserializeAs, deserializeUsing, true);
-        runTests("Normal > Create Instances > Without Target", Instances.Construct, deserializeAs, deserializeUsing, false);
-        runTests("Normal > No Instances > With Target", Instances.Plain, deserializeAs, deserializeUsing, true);
-        runTests("Normal > No Instances > Without Target", Instances.Plain, deserializeAs, deserializeUsing, false);
+        runTests("Normal > Create Instances > With Target", InstantiationMethod.New, deserializeAs, deserializeUsing, true);
+        runTests("Normal > Create Instances > Without Target", InstantiationMethod.New, deserializeAs, deserializeUsing, false);
+        runTests("Normal > No Instances > With Target", InstantiationMethod.None, deserializeAs, deserializeUsing, true);
+        runTests("Normal > No Instances > Without Target", InstantiationMethod.None, deserializeAs, deserializeUsing, false);
 
     });
 
@@ -980,7 +980,7 @@ describe("Deserializing", function () {
             }
 
             const json = { value: 100 };
-            const instance = Deserialize(json, Test, null, Instances.Construct);
+            const instance = Deserialize(json, Test, null, InstantiationMethod.New);
             expect(instance).toEqual({
                 something: "here",
                 value: 100
@@ -1005,7 +1005,7 @@ describe("Deserializing", function () {
             }
 
             const json = { value: 100 };
-            const instance = Deserialize(json, Test, null, Instances.Construct);
+            const instance = Deserialize(json, Test, null, InstantiationMethod.New);
             expect(instance).toEqual({
                 something: "here",
                 value: 300
@@ -1029,7 +1029,7 @@ describe("Deserializing", function () {
 			}
 
 			const json = {};
-			const instance = Deserialize(json, Test, null, Instances.Construct);
+			const instance = Deserialize(json, Test, null, InstantiationMethod.New);
 			expect(instance).toEqual({
 				constructed: true
 			});
@@ -1049,7 +1049,7 @@ describe("Deserializing", function () {
 			}
 
 			const json = {};
-			const instance = Deserialize(json, Test, null, Instances.Create);
+			const instance = Deserialize(json, Test, null, InstantiationMethod.ObjectCreate);
 			expect(instance.constructed).toBeUndefined();
 
 		});
@@ -1060,7 +1060,7 @@ describe("Deserializing", function () {
 			}
 
 			const json = {};
-			const instance = Deserialize(json, Test, null, Instances.Plain);
+			const instance = Deserialize(json, Test, null, InstantiationMethod.None);
 			expect(typeof instance).toEqual('object');
 			expect(instance instanceof Test).toEqual(false);
 		});

--- a/spec/deserialize.spec.ts
+++ b/spec/deserialize.spec.ts
@@ -1014,9 +1014,9 @@ describe("Deserializing", function () {
 
     });
 
-	describe("Instances Creation", function () {
+	describe("InstantiationMethod", function () {
 
-		it("Construct", function () {
+		it("New", function () {
 
 			class Test {
 
@@ -1036,7 +1036,7 @@ describe("Deserializing", function () {
 
 		});
 
-		it("Create", function () {
+		it("ObjectCreate", function () {
 
 			class Test {
 
@@ -1054,7 +1054,7 @@ describe("Deserializing", function () {
 
 		});
 
-		it("Plain", function () {
+		it("None", function () {
 
 			class Test {
 			}

--- a/spec/deserialize.spec.ts
+++ b/spec/deserialize.spec.ts
@@ -9,7 +9,8 @@ import {
     deserializeAsArray,
     deserializeAsJson,
     deserializeAsMap,
-    deserializeUsing, SetDeserializeKeyTransform
+    deserializeUsing, SetDeserializeKeyTransform,
+    SetDefaultInstantiationMethod
 }                                                   from "../src";
 import {InstantiationMethod, Indexable, JsonObject} from "../src/util";
 
@@ -1061,6 +1062,21 @@ describe("Deserializing", function () {
 
 			const json = {};
 			const instance = Deserialize(json, Test, null, InstantiationMethod.None);
+			expect(typeof instance).toEqual('object');
+			expect(instance instanceof Test).toEqual(false);
+		});
+
+		it("SetDefaultInstantiationMethod", function () {
+			SetDefaultInstantiationMethod(InstantiationMethod.None);
+
+			class Test {
+			}
+
+			const json = {};
+			const instance = Deserialize(json, Test, null, InstantiationMethod.None);
+
+			SetDefaultInstantiationMethod(null); // Reset.
+
 			expect(typeof instance).toEqual('object');
 			expect(instance instanceof Test).toEqual(false);
 		});

--- a/spec/deserialize.spec.ts
+++ b/spec/deserialize.spec.ts
@@ -11,28 +11,38 @@ import {
     deserializeAsMap,
     deserializeUsing, SetDeserializeKeyTransform
 } from "../src";
-import {Indexable, JsonObject} from "../src/util";
+import {Instances, Indexable, JsonObject} from "../src/util";
 
-function expectInstance(instance : any, type : any, createInstances : boolean) {
-    if (createInstances) {
-        expect(instance instanceof type).toBe(true);
-    }
-    else {
-        expect(instance instanceof type).toBeFalsy();
-        expect(instance.toString()).toBe("[object Object]");
-    }
+function expectInstance(instance : any, type : any, createInstances : Instances) {
+    switch (createInstances) {
+		case Instances.Construct:
+		case Instances.Create:
+			expect(instance instanceof type).toBe(true);
+			break;
+
+		case Instances.Plain:
+			expect(instance instanceof type).toBeFalsy();
+			expect(instance.toString()).toBe("[object Object]");
+			break;
+	}
 }
 
 function expectTarget(target : any, instance : any, shouldMakeTarget : boolean) {
     expect(instance === target).toBe(shouldMakeTarget);
 }
 
-function createTarget(shouldMakeTarget : boolean, shouldCreateInstances : boolean, type : any) {
-    if (shouldMakeTarget) {
-        return shouldCreateInstances ? new type() : {};
-    }
-    else {
-        return null;
+function createTarget(shouldMakeTarget : boolean, shouldCreateInstances : Instances, type : any) {
+    if (!shouldMakeTarget) return null;
+
+    switch (shouldCreateInstances) {
+        case Instances.Construct:
+            return new type();
+
+        case Instances.Create:
+            return Object.create(type.prototype);
+
+        case Instances.Plain:
+            return {};
     }
 }
 
@@ -56,7 +66,7 @@ describe("Deserializing", function () {
 
     describe("DeserializeAs", function () {
 
-        function runTests(blockName : string, createInstances : boolean, deserializeAs : any, makeTarget : boolean) {
+        function runTests(blockName : string, createInstances : Instances, deserializeAs : any, makeTarget : boolean) {
 
             describe(blockName, function () {
 
@@ -284,20 +294,20 @@ describe("Deserializing", function () {
 
         }
 
-        runTests("Normal > Create Instances > With Target", true, deserializeAs, true);
-        runTests("Normal > Create Instances > Without Target", true, deserializeAs, false);
-        runTests("Normal > No Instances > With Target", false, deserializeAs, true);
-        runTests("Normal > No Instances > Without Target", false, deserializeAs, false);
-        runTests("Auto > Create Instances > With Target", true, autoserializeAs, true);
-        runTests("Auto > Create Instances > Without Target", true, autoserializeAs, false);
-        runTests("Auto > No Instances > With Target", false, autoserializeAs, true);
-        runTests("Auto > No Instances > Without Target", false, autoserializeAs, false);
+        runTests("Normal > Create Instances > With Target", Instances.Construct, deserializeAs, true);
+        runTests("Normal > Create Instances > Without Target", Instances.Construct, deserializeAs, false);
+        runTests("Normal > No Instances > With Target", Instances.Plain, deserializeAs, true);
+        runTests("Normal > No Instances > Without Target", Instances.Plain, deserializeAs, false);
+        runTests("Auto > Create Instances > With Target", Instances.Construct, autoserializeAs, true);
+        runTests("Auto > Create Instances > Without Target", Instances.Construct, autoserializeAs, false);
+        runTests("Auto > No Instances > With Target", Instances.Plain, autoserializeAs, true);
+        runTests("Auto > No Instances > Without Target", Instances.Plain, autoserializeAs, false);
 
     });
 
     describe("DeserializeAsMap", function () {
 
-        function runTests(blockName : string, createInstances : boolean, deserializeAs : any, deserializeAsMap : any, makeTarget : boolean) {
+        function runTests(blockName : string, createInstances : Instances, deserializeAs : any, deserializeAsMap : any, makeTarget : boolean) {
 
             describe(blockName, function () {
 
@@ -461,20 +471,20 @@ describe("Deserializing", function () {
 
         }
 
-        runTests("Normal > Create Instances > With Target", true, deserializeAs, deserializeAsMap, true);
-        runTests("Normal > Create Instances > Without Target", true, deserializeAs, deserializeAsMap, false);
-        runTests("Normal > No Instances > With Target", false, deserializeAs, deserializeAsMap, true);
-        runTests("Normal > No Instances > Without Target", false, deserializeAs, deserializeAsMap, false);
-        runTests("Auto > Create Instances > With Target", true, autoserializeAs, autoserializeAsMap, true);
-        runTests("Auto > Create Instances > Without Target", true, autoserializeAs, autoserializeAsMap, false);
-        runTests("Auto > No Instances > With Target", false, autoserializeAs, autoserializeAsMap, true);
-        runTests("Auto > No Instances > Without Target", false, autoserializeAs, autoserializeAsMap, false);
+        runTests("Normal > Create Instances > With Target", Instances.Construct, deserializeAs, deserializeAsMap, true);
+        runTests("Normal > Create Instances > Without Target", Instances.Construct, deserializeAs, deserializeAsMap, false);
+        runTests("Normal > No Instances > With Target", Instances.Plain, deserializeAs, deserializeAsMap, true);
+        runTests("Normal > No Instances > Without Target", Instances.Plain, deserializeAs, deserializeAsMap, false);
+        runTests("Auto > Create Instances > With Target", Instances.Construct, autoserializeAs, autoserializeAsMap, true);
+        runTests("Auto > Create Instances > Without Target", Instances.Construct, autoserializeAs, autoserializeAsMap, false);
+        runTests("Auto > No Instances > With Target", Instances.Plain, autoserializeAs, autoserializeAsMap, true);
+        runTests("Auto > No Instances > Without Target", Instances.Plain, autoserializeAs, autoserializeAsMap, false);
 
     });
 
     describe("DeserializeAsArray", function () {
 
-        function runTests(blockName : string, createInstances : boolean, deserializeAs : any, deserializeAsArray : any, makeTarget : boolean) {
+        function runTests(blockName : string, createInstances : Instances, deserializeAs : any, deserializeAsArray : any, makeTarget : boolean) {
 
             describe(blockName, function () {
 
@@ -631,20 +641,20 @@ describe("Deserializing", function () {
 
         }
 
-        runTests("Normal > Create Instances > With Target", true, deserializeAs, deserializeAsArray, true);
-        runTests("Normal > Create Instances > Without Target", true, deserializeAs, deserializeAsArray, false);
-        runTests("Normal > No Instances > With Target", false, deserializeAs, deserializeAsArray, true);
-        runTests("Normal > No Instances > Without Target", false, deserializeAs, deserializeAsArray, false);
-        runTests("Auto > Create Instances > With Target", true, autoserializeAs, autoserializeAsArray, true);
-        runTests("Auto > Create Instances > Without Target", true, autoserializeAs, autoserializeAsArray, false);
-        runTests("Auto > No Instances > With Target", false, autoserializeAs, autoserializeAsArray, true);
-        runTests("Auto > No Instances > Without Target", false, autoserializeAs, autoserializeAsArray, false);
+        runTests("Normal > Create Instances > With Target", Instances.Construct, deserializeAs, deserializeAsArray, true);
+        runTests("Normal > Create Instances > Without Target", Instances.Construct, deserializeAs, deserializeAsArray, false);
+        runTests("Normal > No Instances > With Target", Instances.Plain, deserializeAs, deserializeAsArray, true);
+        runTests("Normal > No Instances > Without Target", Instances.Plain, deserializeAs, deserializeAsArray, false);
+        runTests("Auto > Create Instances > With Target", Instances.Construct, autoserializeAs, autoserializeAsArray, true);
+        runTests("Auto > Create Instances > Without Target", Instances.Construct, autoserializeAs, autoserializeAsArray, false);
+        runTests("Auto > No Instances > With Target", Instances.Plain, autoserializeAs, autoserializeAsArray, true);
+        runTests("Auto > No Instances > Without Target", Instances.Plain, autoserializeAs, autoserializeAsArray, false);
 
     });
 
     describe("DeserializeJSON", function () {
 
-        function runTests(blockName : string, createInstances : boolean, deserializeAs : any, deserializeAsJson : any, makeTarget : boolean) {
+        function runTests(blockName : string, createInstances : Instances, deserializeAs : any, deserializeAsJson : any, makeTarget : boolean) {
 
             describe(blockName, function () {
 
@@ -909,20 +919,20 @@ describe("Deserializing", function () {
             });
         }
 
-        runTests("Normal > Create Instances > With Target", true, deserializeAs, deserializeAsJson, true);
-        runTests("Normal > Create Instances > Without Target", true, deserializeAs, deserializeAsJson, false);
-        runTests("Normal > No Instances > With Target", false, deserializeAs, deserializeAsJson, true);
-        runTests("Normal > No Instances > Without Target", false, deserializeAs, deserializeAsJson, false);
-        runTests("Auto > Create Instances > With Target", true, autoserializeAs, autoserializeAsJson, true);
-        runTests("Auto > Create Instances > Without Target", true, autoserializeAs, autoserializeAsJson, false);
-        runTests("Auto > No Instances > With Target", false, autoserializeAs, autoserializeAsJson, true);
-        runTests("Auto > No Instances > Without Target", false, autoserializeAs, autoserializeAsJson, false);
+        runTests("Normal > Create Instances > With Target", Instances.Construct, deserializeAs, deserializeAsJson, true);
+        runTests("Normal > Create Instances > Without Target", Instances.Construct, deserializeAs, deserializeAsJson, false);
+        runTests("Normal > No Instances > With Target", Instances.Plain, deserializeAs, deserializeAsJson, true);
+        runTests("Normal > No Instances > Without Target", Instances.Plain, deserializeAs, deserializeAsJson, false);
+        runTests("Auto > Create Instances > With Target", Instances.Construct, autoserializeAs, autoserializeAsJson, true);
+        runTests("Auto > Create Instances > Without Target", Instances.Construct, autoserializeAs, autoserializeAsJson, false);
+        runTests("Auto > No Instances > With Target", Instances.Plain, autoserializeAs, autoserializeAsJson, true);
+        runTests("Auto > No Instances > Without Target", Instances.Plain, autoserializeAs, autoserializeAsJson, false);
 
     });
 
     describe("DeserializeUsing", function () {
 
-        function runTests(blockName : string, createInstances : boolean, deserializeAs : any, deserializeUsing : any, makeTarget : boolean) {
+        function runTests(blockName : string, createInstances : Instances, deserializeAs : any, deserializeUsing : any, makeTarget : boolean) {
 
             it("uses the provided function", function () {
                 function x(value : any) { return 1; }
@@ -947,10 +957,10 @@ describe("Deserializing", function () {
 
         }
 
-        runTests("Normal > Create Instances > With Target", true, deserializeAs, deserializeUsing, true);
-        runTests("Normal > Create Instances > Without Target", true, deserializeAs, deserializeUsing, false);
-        runTests("Normal > No Instances > With Target", false, deserializeAs, deserializeUsing, true);
-        runTests("Normal > No Instances > Without Target", false, deserializeAs, deserializeUsing, false);
+        runTests("Normal > Create Instances > With Target", Instances.Construct, deserializeAs, deserializeUsing, true);
+        runTests("Normal > Create Instances > Without Target", Instances.Construct, deserializeAs, deserializeUsing, false);
+        runTests("Normal > No Instances > With Target", Instances.Plain, deserializeAs, deserializeUsing, true);
+        runTests("Normal > No Instances > Without Target", Instances.Plain, deserializeAs, deserializeUsing, false);
 
     });
 
@@ -970,7 +980,7 @@ describe("Deserializing", function () {
             }
 
             const json = { value: 100 };
-            const instance = Deserialize(json, Test, null, true);
+            const instance = Deserialize(json, Test, null, Instances.Construct);
             expect(instance).toEqual({
                 something: "here",
                 value: 100
@@ -995,7 +1005,7 @@ describe("Deserializing", function () {
             }
 
             const json = { value: 100 };
-            const instance = Deserialize(json, Test, null, true);
+            const instance = Deserialize(json, Test, null, Instances.Construct);
             expect(instance).toEqual({
                 something: "here",
                 value: 300

--- a/spec/deserialize.spec.ts
+++ b/spec/deserialize.spec.ts
@@ -13,8 +13,8 @@ import {
 }                                                   from "../src";
 import {InstantiationMethod, Indexable, JsonObject} from "../src/util";
 
-function expectInstance(instance : any, type : any, createInstances : InstantiationMethod) {
-    switch (createInstances) {
+function expectInstance(instance : any, type : any, instantiationMethod : InstantiationMethod) {
+    switch (instantiationMethod) {
 		case InstantiationMethod.New:
 		case InstantiationMethod.ObjectCreate:
 			expect(instance instanceof type).toBe(true);
@@ -31,10 +31,10 @@ function expectTarget(target : any, instance : any, shouldMakeTarget : boolean) 
     expect(instance === target).toBe(shouldMakeTarget);
 }
 
-function createTarget(shouldMakeTarget : boolean, shouldCreateInstances : InstantiationMethod, type : any) {
+function createTarget(shouldMakeTarget : boolean, shouldinstantiationMethod : InstantiationMethod, type : any) {
     if (!shouldMakeTarget) return null;
 
-    switch (shouldCreateInstances) {
+    switch (shouldinstantiationMethod) {
         case InstantiationMethod.New:
             return new type();
 
@@ -66,7 +66,7 @@ describe("Deserializing", function () {
 
     describe("DeserializeAs", function () {
 
-        function runTests(blockName : string, createInstances : InstantiationMethod, deserializeAs : any, makeTarget : boolean) {
+        function runTests(blockName : string, instantiationMethod : InstantiationMethod, deserializeAs : any, makeTarget : boolean) {
 
             describe(blockName, function () {
 
@@ -78,17 +78,17 @@ describe("Deserializing", function () {
                         @deserializeAs(Number) value2 : number = 100;
                     }
 
-                    const target = createTarget(makeTarget, createInstances, Test);
+                    const target = createTarget(makeTarget, instantiationMethod, Test);
                     const instance = Deserialize({
                         value0: "strvalue1",
                         value1: false,
                         value2: 101
-                    }, Test, target, createInstances);
+                    }, Test, target, instantiationMethod);
                     expect(instance.value0).toBe("strvalue1");
                     expect(instance.value1).toBe(false);
                     expect(instance.value2).toBe(101);
                     expectTarget(instance, target, makeTarget);
-                    expectInstance(instance, Test, createInstances);
+                    expectInstance(instance, Test, instantiationMethod);
 
                 });
 
@@ -98,12 +98,12 @@ describe("Deserializing", function () {
                     }
 
                     const d = new Date().toString();
-                    const target = createTarget(makeTarget, createInstances, Test);
-                    const instance = Deserialize({ value0: d }, Test, target, createInstances);
+                    const target = createTarget(makeTarget, instantiationMethod, Test);
+                    const instance = Deserialize({ value0: d }, Test, target, instantiationMethod);
                     expect(instance.value0 instanceof Date).toBe(true);
                     expect(instance.value0.toString()).toBe(d);
                     expectTarget(target, instance, makeTarget);
-                    expectInstance(instance, Test, createInstances);
+                    expectInstance(instance, Test, instantiationMethod);
                 });
 
                 it("deserializes a RegExp", function () {
@@ -112,12 +112,12 @@ describe("Deserializing", function () {
                     }
 
                     const d = (new RegExp("/[123]/g")).toString();
-                    const target = createTarget(makeTarget, createInstances, Test);
-                    const instance = Deserialize({ value0: d }, Test, target, createInstances);
+                    const target = createTarget(makeTarget, instantiationMethod, Test);
+                    const instance = Deserialize({ value0: d }, Test, target, instantiationMethod);
                     expect(instance.value0 instanceof RegExp).toBe(true);
                     expect(instance.value0.toString()).toBe(d);
                     expectTarget(instance, target, makeTarget);
-                    expectInstance(instance, Test, createInstances);
+                    expectInstance(instance, Test, instantiationMethod);
 
                 });
 
@@ -130,16 +130,16 @@ describe("Deserializing", function () {
                         @deserializeAs(Thing) thing : Thing;
                     }
 
-                    const target = createTarget(makeTarget, createInstances, Test);
-                    if (target) target.thing = createTarget(makeTarget, createInstances, Thing);
-                    const instance = Deserialize({ thing: { value: 2 } }, Test, target, createInstances);
+                    const target = createTarget(makeTarget, instantiationMethod, Test);
+                    if (target) target.thing = createTarget(makeTarget, instantiationMethod, Thing);
+                    const instance = Deserialize({ thing: { value: 2 } }, Test, target, instantiationMethod);
                     expect(instance.thing.value).toBe(2);
                     expectTarget(target, instance, makeTarget);
                     if (target) {
                         expectTarget(target.thing, instance.thing, makeTarget);
                     }
-                    expectInstance(instance.thing, Thing, createInstances);
-                    expectInstance(instance, Test, createInstances);
+                    expectInstance(instance.thing, Thing, instantiationMethod);
+                    expectInstance(instance, Test, instantiationMethod);
                 });
 
                 it("deserializes non matching primitive types", function () {
@@ -154,8 +154,8 @@ describe("Deserializing", function () {
                         value1: true,
                         value2: "100"
                     };
-                    const target = createTarget(makeTarget, createInstances, Test);
-                    const instance = Deserialize(json, Test, target, createInstances);
+                    const target = createTarget(makeTarget, instantiationMethod, Test);
+                    const instance = Deserialize(json, Test, target, instantiationMethod);
                     expect(instance.value0).toBe(100);
                     expect(instance.value1).toBe("true");
                     expect(instance.value2).toBe(true);
@@ -174,8 +174,8 @@ describe("Deserializing", function () {
                         bool: true,
                         num: 100
                     };
-                    const target = createTarget(makeTarget, createInstances, Test);
-                    const instance = Deserialize(json, Test, target, createInstances);
+                    const target = createTarget(makeTarget, instantiationMethod, Test);
+                    const instance = Deserialize(json, Test, target, instantiationMethod);
                     expect(instance.value0).toBe("strval");
                     expect(instance.value1).toBe(true);
                     expect(instance.value2).toBe(100);
@@ -194,9 +194,9 @@ describe("Deserializing", function () {
                         value1: true,
                         value2: 100
                     };
-                    const target = createTarget(makeTarget, createInstances, Test);
-                    const instance = Deserialize(json, Test, target, createInstances);
-                    if (createInstances) {
+                    const target = createTarget(makeTarget, instantiationMethod, Test);
+                    const instance = Deserialize(json, Test, target, instantiationMethod);
+                    if (instantiationMethod) {
                         expect(instance.value0).toBe("val");
                     }
                     else {
@@ -218,8 +218,8 @@ describe("Deserializing", function () {
                         value1: true,
                         value2: 100
                     };
-                    const target = createTarget(makeTarget, createInstances, Test);
-                    const instance = Deserialize(json, Test, target, createInstances);
+                    const target = createTarget(makeTarget, instantiationMethod, Test);
+                    const instance = Deserialize(json, Test, target, instantiationMethod);
                     expect(instance.value0).toBe(null);
                     expect(instance.value1).toBe(true);
                     expect(instance.value2).toBe(100);
@@ -241,11 +241,11 @@ describe("Deserializing", function () {
                     const json = {
                         test: { value0: "str", value1: true, value2: 100 }
                     };
-                    const target = createTarget(makeTarget, createInstances, Test0);
-                    if (target) target.test = createTarget(makeTarget, createInstances, Test);
-                    const instance = Deserialize(json, Test0, target, createInstances);
-                    expectInstance(instance.test, Test, createInstances);
-                    if (target) expectInstance(target.test, Test, createInstances);
+                    const target = createTarget(makeTarget, instantiationMethod, Test0);
+                    if (target) target.test = createTarget(makeTarget, instantiationMethod, Test);
+                    const instance = Deserialize(json, Test0, target, instantiationMethod);
+                    expectInstance(instance.test, Test, instantiationMethod);
+                    if (target) expectInstance(target.test, Test, instantiationMethod);
                     expect(instance.test.value0).toBe("str");
                     expect(instance.test.value1).toBe(true);
                     expect(instance.test.value2).toBe(100);
@@ -270,16 +270,16 @@ describe("Deserializing", function () {
                         test1: { test0: { value0: "str", value1: true, value2: 100 } }
                     };
 
-                    const target = createTarget(makeTarget, createInstances, Test2);
+                    const target = createTarget(makeTarget, instantiationMethod, Test2);
                     if (target) {
-                        target.test1 = createTarget(makeTarget, createInstances, Test1);
+                        target.test1 = createTarget(makeTarget, instantiationMethod, Test1);
                         if (target.test1) {
-                            target.test1.test0 = createTarget(makeTarget, createInstances, Test0);
+                            target.test1.test0 = createTarget(makeTarget, instantiationMethod, Test0);
                         }
                     }
-                    const instance = Deserialize(json, Test2, target, createInstances);
-                    expectInstance(instance.test1, Test1, createInstances);
-                    expectInstance(instance.test1.test0, Test0, createInstances);
+                    const instance = Deserialize(json, Test2, target, instantiationMethod);
+                    expectInstance(instance.test1, Test1, instantiationMethod);
+                    expectInstance(instance.test1.test0, Test0, instantiationMethod);
                     if (target) {
                         expectTarget(target, instance, makeTarget);
                         expectTarget(target.test1, instance.test1, makeTarget);
@@ -307,7 +307,7 @@ describe("Deserializing", function () {
 
     describe("DeserializeAsMap", function () {
 
-        function runTests(blockName : string, createInstances : InstantiationMethod, deserializeAs : any, deserializeAsMap : any, makeTarget : boolean) {
+        function runTests(blockName : string, instantiationMethod : InstantiationMethod, deserializeAs : any, deserializeAsMap : any, makeTarget : boolean) {
 
             describe(blockName, function () {
 
@@ -318,10 +318,10 @@ describe("Deserializing", function () {
                     }
 
                     const json = { values: { v0: 0, v1: 1, v2: 2 } };
-                    const target = createTarget(makeTarget, createInstances, Test);
-                    const instance = Deserialize(json, Test, target, createInstances);
+                    const target = createTarget(makeTarget, instantiationMethod, Test);
+                    const instance = Deserialize(json, Test, target, instantiationMethod);
                     expect(instance.values).toEqual({ v0: 0, v1: 1, v2: 2 });
-                    expectInstance(instance, Test, createInstances);
+                    expectInstance(instance, Test, instantiationMethod);
                     expectTarget(target, instance, makeTarget);
 
                 });
@@ -347,8 +347,8 @@ describe("Deserializing", function () {
                         }
                     };
 
-                    const target = createTarget(makeTarget, createInstances, Test);
-                    const instance = Deserialize(json, Test, target, createInstances);
+                    const target = createTarget(makeTarget, instantiationMethod, Test);
+                    const instance = Deserialize(json, Test, target, instantiationMethod);
                     expect(instance.values.v0).toEqual({ value: 1 });
                     expect(instance.values.v1).toEqual({ value: 2 });
                     expect(instance.values.v2).toEqual({ value: 3 });
@@ -374,8 +374,8 @@ describe("Deserializing", function () {
                             v2: { value: { v20: 3, v21: 2 } }
                         }
                     };
-                    const target = createTarget(makeTarget, createInstances, Test);
-                    const instance = Deserialize(json, Test, target, createInstances);
+                    const target = createTarget(makeTarget, instantiationMethod, Test);
+                    const instance = Deserialize(json, Test, target, instantiationMethod);
                     expect(instance.values).toEqual({
                         v0: { value: { v00: 1, v01: 2 } },
                         v1: { value: { v10: 2, v11: 2 } },
@@ -395,8 +395,8 @@ describe("Deserializing", function () {
                             v2: 2
                         }
                     };
-                    const target = createTarget(makeTarget, createInstances, Test);
-                    const instance = Deserialize(json, Test, target, createInstances);
+                    const target = createTarget(makeTarget, instantiationMethod, Test);
+                    const instance = Deserialize(json, Test, target, instantiationMethod);
                     expect(instance).toEqual({
                         values: {
                             v1: 1,
@@ -421,8 +421,8 @@ describe("Deserializing", function () {
                     const json = {
                         different: { v0: { value: 1 }, v1: { value: 2 } }
                     };
-                    const target = createTarget(makeTarget, createInstances, Test);
-                    const instance = Deserialize(json, Test, target, createInstances);
+                    const target = createTarget(makeTarget, instantiationMethod, Test);
+                    const instance = Deserialize(json, Test, target, instantiationMethod);
                     expect(instance.values).toEqual({
                         v0: { value: 1 }, v1: { value: 2 }
                     });
@@ -436,20 +436,20 @@ describe("Deserializing", function () {
 
                     expect(function () {
                         const json = { values: 1 };
-                        const target = createTarget(makeTarget, createInstances, Test);
-                        const instance = Deserialize(json, Test, target, createInstances);
+                        const target = createTarget(makeTarget, instantiationMethod, Test);
+                        const instance = Deserialize(json, Test, target, instantiationMethod);
                     }).toThrow("Expected input to be of type `object` but received: number");
 
                     expect(function () {
                         const json = { values: false };
-                        const target = createTarget(makeTarget, createInstances, Test);
-                        const instance = Deserialize(json, Test, target, createInstances);
+                        const target = createTarget(makeTarget, instantiationMethod, Test);
+                        const instance = Deserialize(json, Test, target, instantiationMethod);
                     }).toThrow("Expected input to be of type `object` but received: boolean");
 
                     expect(function () {
                         const json = { values: "str" };
-                        const target = createTarget(makeTarget, createInstances, Test);
-                        const instance = Deserialize(json, Test, target, createInstances);
+                        const target = createTarget(makeTarget, instantiationMethod, Test);
+                        const instance = Deserialize(json, Test, target, instantiationMethod);
                     }).toThrow("Expected input to be of type `object` but received: string");
 
                 });
@@ -461,8 +461,8 @@ describe("Deserializing", function () {
                     }
 
                     const json : any = { values: null };
-                    const target = createTarget(makeTarget, createInstances, Test);
-                    const instance = Deserialize(json, Test, target, createInstances);
+                    const target = createTarget(makeTarget, instantiationMethod, Test);
+                    const instance = Deserialize(json, Test, target, instantiationMethod);
                     expect(instance.values).toBeNull();
 
                 });
@@ -484,7 +484,7 @@ describe("Deserializing", function () {
 
     describe("DeserializeAsArray", function () {
 
-        function runTests(blockName : string, createInstances : InstantiationMethod, deserializeAs : any, deserializeAsArray : any, makeTarget : boolean) {
+        function runTests(blockName : string, instantiationMethod : InstantiationMethod, deserializeAs : any, deserializeAsArray : any, makeTarget : boolean) {
 
             describe(blockName, function () {
 
@@ -494,11 +494,11 @@ describe("Deserializing", function () {
                     }
 
                     const json = { value: [1, 2, 3] };
-                    const target = createTarget(makeTarget, createInstances, Test);
-                    const instance = Deserialize(json, Test, target, createInstances);
+                    const target = createTarget(makeTarget, instantiationMethod, Test);
+                    const instance = Deserialize(json, Test, target, instantiationMethod);
                     expect(Array.isArray(instance.value)).toBeTruthy();
                     expect(instance.value).toEqual([1, 2, 3]);
-                    expectInstance(instance, Test, createInstances);
+                    expectInstance(instance, Test, instantiationMethod);
                     expectTarget(target, instance, makeTarget);
                 });
 
@@ -523,16 +523,16 @@ describe("Deserializing", function () {
                         ]
                     };
 
-                    const target = createTarget(makeTarget, createInstances, Test);
-                    const instance = Deserialize(json, Test, target, createInstances);
-                    expectInstance(instance, Test, createInstances);
+                    const target = createTarget(makeTarget, instantiationMethod, Test);
+                    const instance = Deserialize(json, Test, target, instantiationMethod);
+                    expectInstance(instance, Test, instantiationMethod);
                     expectTarget(target, instance, makeTarget);
                     expect(instance.value).toEqual([
                         { strVal: "0" },
                         { strVal: "1" },
                         { strVal: "2" }
                     ]);
-                    if (createInstances) {
+                    if (instantiationMethod) {
                         expect(instance.value[0] instanceof TestType).toBeTruthy();
                         expect(instance.value[1] instanceof TestType).toBeTruthy();
                         expect(instance.value[2] instanceof TestType).toBeTruthy();
@@ -577,10 +577,10 @@ describe("Deserializing", function () {
                         new TestTypeL1([new TestTypeL0("20"), new TestTypeL0("21")])
                     ];
 
-                    const target = createTarget(makeTarget, createInstances, Test);
-                    const instance = Deserialize(json, Test, target, createInstances);
+                    const target = createTarget(makeTarget, instantiationMethod, Test);
+                    const instance = Deserialize(json, Test, target, instantiationMethod);
                     expect(instance).toEqual({ value: array });
-                    if (createInstances) {
+                    if (instantiationMethod) {
                         expect(instance.value[0] instanceof TestTypeL1).toBeTruthy();
                         expect(instance.value[1] instanceof TestTypeL1).toBeTruthy();
                         expect(instance.value[2] instanceof TestTypeL1).toBeTruthy();
@@ -596,9 +596,9 @@ describe("Deserializing", function () {
 
                     const json = { different: [1, 2, 3] };
 
-                    const target = createTarget(makeTarget, createInstances, Test);
-                    const instance = Deserialize(json, Test, target, createInstances);
-                    expectInstance(instance, Test, createInstances);
+                    const target = createTarget(makeTarget, instantiationMethod, Test);
+                    const instance = Deserialize(json, Test, target, instantiationMethod);
+                    expectInstance(instance, Test, instantiationMethod);
                     expectTarget(target, instance, makeTarget);
                     expect(instance).toEqual({
                         value: [1, 2, 3]
@@ -613,26 +613,26 @@ describe("Deserializing", function () {
 
                     expect(function () {
                         const json = { values: 1 };
-                        const target = createTarget(makeTarget, createInstances, Test);
-                        const instance = Deserialize(json, Test, target, createInstances);
+                        const target = createTarget(makeTarget, instantiationMethod, Test);
+                        const instance = Deserialize(json, Test, target, instantiationMethod);
                     }).toThrow("Expected input to be an array but received: number");
 
                     expect(function () {
                         const json = { values: false };
-                        const target = createTarget(makeTarget, createInstances, Test);
-                        const instance = Deserialize(json, Test, target, createInstances);
+                        const target = createTarget(makeTarget, instantiationMethod, Test);
+                        const instance = Deserialize(json, Test, target, instantiationMethod);
                     }).toThrow("Expected input to be an array but received: boolean");
 
                     expect(function () {
                         const json = { values: "str" };
-                        const target = createTarget(makeTarget, createInstances, Test);
-                        const instance = Deserialize(json, Test, target, createInstances);
+                        const target = createTarget(makeTarget, instantiationMethod, Test);
+                        const instance = Deserialize(json, Test, target, instantiationMethod);
                     }).toThrow("Expected input to be an array but received: string");
 
                     expect(function () {
                         const json = { values: {} };
-                        const target = createTarget(makeTarget, createInstances, Test);
-                        const instance = Deserialize(json, Test, target, createInstances);
+                        const target = createTarget(makeTarget, instantiationMethod, Test);
+                        const instance = Deserialize(json, Test, target, instantiationMethod);
                     }).toThrow("Expected input to be an array but received: object");
 
                 });
@@ -654,7 +654,7 @@ describe("Deserializing", function () {
 
     describe("DeserializeJSON", function () {
 
-        function runTests(blockName : string, createInstances : InstantiationMethod, deserializeAs : any, deserializeAsJson : any, makeTarget : boolean) {
+        function runTests(blockName : string, instantiationMethod : InstantiationMethod, deserializeAs : any, deserializeAsJson : any, makeTarget : boolean) {
 
             describe(blockName, function () {
 
@@ -672,8 +672,8 @@ describe("Deserializing", function () {
                         value2: 1
                     };
 
-                    const target = createTarget(makeTarget, createInstances, Test);
-                    const instance = Deserialize(json, Test, target, createInstances);
+                    const target = createTarget(makeTarget, instantiationMethod, Test);
+                    const instance = Deserialize(json, Test, target, instantiationMethod);
                     expect(instance).toEqual({
                         value0: "strval",
                         value1: true,
@@ -695,8 +695,8 @@ describe("Deserializing", function () {
                         value1: [false, true],
                         value2: 100
                     };
-                    const target = createTarget(makeTarget, createInstances, Test);
-                    const instance = Deserialize(json, Test, target, createInstances);
+                    const target = createTarget(makeTarget, instantiationMethod, Test);
+                    const instance = Deserialize(json, Test, target, instantiationMethod);
                     expect(instance).toEqual({
                         value0: ["strvalue", "00"],
                         value1: [false, true],
@@ -718,8 +718,8 @@ describe("Deserializing", function () {
                         }
                     };
 
-                    const target = createTarget(makeTarget, createInstances, Test);
-                    const instance = Deserialize(json, Test, target, createInstances);
+                    const target = createTarget(makeTarget, instantiationMethod, Test);
+                    const instance = Deserialize(json, Test, target, instantiationMethod);
                     expect(instance).toEqual({
                         value: {
                             v0: 1,
@@ -743,8 +743,8 @@ describe("Deserializing", function () {
                             { x: 3, y: 1 },
                         ]
                     };
-                    const target = createTarget(makeTarget, createInstances, Test);
-                    const instance = Deserialize(json, Test, target, createInstances);
+                    const target = createTarget(makeTarget, instantiationMethod, Test);
+                    const instance = Deserialize(json, Test, target, instantiationMethod);
                     expect(instance).toEqual({
                         things: [
                             { x: 1, y: 3 },
@@ -765,8 +765,8 @@ describe("Deserializing", function () {
                             x: 1, y: 2, z: 3
                         }
                     };
-                    const target = createTarget(makeTarget, createInstances, Test);
-                    const instance = Deserialize(json, Test, target, createInstances);
+                    const target = createTarget(makeTarget, instantiationMethod, Test);
+                    const instance = Deserialize(json, Test, target, instantiationMethod);
                     expect(instance).toEqual({
                         things: { x: 1, y: 2, z: 3 }
                     });
@@ -786,8 +786,8 @@ describe("Deserializing", function () {
                             v2: { x: 3, y: 1 },
                         }
                     };
-                    const target = createTarget(makeTarget, createInstances, Test);
-                    const instance = Deserialize(json, Test, target, createInstances);
+                    const target = createTarget(makeTarget, instantiationMethod, Test);
+                    const instance = Deserialize(json, Test, target, instantiationMethod);
                     expect(instance).toEqual({
                         things: {
                             v0: { x: 1, y: 3 },
@@ -810,8 +810,8 @@ describe("Deserializing", function () {
                             [4, 5, 6]
                         ]
                     };
-                    const target = createTarget(makeTarget, createInstances, Test);
-                    const instance = Deserialize(json, Test, target, createInstances);
+                    const target = createTarget(makeTarget, instantiationMethod, Test);
+                    const instance = Deserialize(json, Test, target, instantiationMethod);
                     expect(instance).toEqual({
                         things: [
                             [1, 2, 3],
@@ -831,8 +831,8 @@ describe("Deserializing", function () {
                         things: [],
                         fn: function () {}
                     };
-                    const target = createTarget(makeTarget, createInstances, Test);
-                    const instance = Deserialize(json, Test, target, createInstances);
+                    const target = createTarget(makeTarget, instantiationMethod, Test);
+                    const instance = Deserialize(json, Test, target, instantiationMethod);
                     expect(instance).toEqual({
                         things: []
                     });
@@ -851,8 +851,8 @@ describe("Deserializing", function () {
                             x: 1, y: 2, z: 3
                         }
                     };
-                    const target = createTarget(makeTarget, createInstances, Test);
-                    const instance = Deserialize(json, Test, target, createInstances);
+                    const target = createTarget(makeTarget, instantiationMethod, Test);
+                    const instance = Deserialize(json, Test, target, instantiationMethod);
                     expect(instance).toEqual({
                         things: { x: 1, y: 2, z: 3 }
                     });
@@ -875,8 +875,8 @@ describe("Deserializing", function () {
                         VALUE2: 100
                     };
 
-                    const target = createTarget(makeTarget, createInstances, Test);
-                    const instance = Deserialize(json, Test, target, createInstances);
+                    const target = createTarget(makeTarget, instantiationMethod, Test);
+                    const instance = Deserialize(json, Test, target, instantiationMethod);
                     SetDeserializeKeyTransform(null);
                     expect(instance).toEqual({
                         value0: "strvalue",
@@ -902,8 +902,8 @@ describe("Deserializing", function () {
                         VALUE2: 100
                     };
 
-                    const target = createTarget(makeTarget, createInstances, Test);
-                    const instance = Deserialize(json, Test, target, createInstances);
+                    const target = createTarget(makeTarget, instantiationMethod, Test);
+                    const instance = Deserialize(json, Test, target, instantiationMethod);
                     SetDeserializeKeyTransform(null);
                     expect(instance).toEqual({
                         value0: "strvalue",
@@ -932,7 +932,7 @@ describe("Deserializing", function () {
 
     describe("DeserializeUsing", function () {
 
-        function runTests(blockName : string, createInstances : InstantiationMethod, deserializeAs : any, deserializeUsing : any, makeTarget : boolean) {
+        function runTests(blockName : string, instantiationMethod : InstantiationMethod, deserializeAs : any, deserializeUsing : any, makeTarget : boolean) {
 
             it("uses the provided function", function () {
                 function x(value : any) { return 1; }
@@ -947,10 +947,10 @@ describe("Deserializing", function () {
                     value1: "hello"
                 };
 
-                const target = createTarget(makeTarget, createInstances, Test);
-                const instance = Deserialize(json, Test, target, createInstances);
+                const target = createTarget(makeTarget, instantiationMethod, Test);
+                const instance = Deserialize(json, Test, target, instantiationMethod);
                 expectTarget(target, instance, makeTarget);
-                expectInstance(instance, Test, createInstances);
+                expectInstance(instance, Test, instantiationMethod);
                 expect(instance).toEqual({ value: 1, value1: 1 });
 
             });

--- a/spec/deserialize.spec.ts
+++ b/spec/deserialize.spec.ts
@@ -1014,4 +1014,57 @@ describe("Deserializing", function () {
 
     });
 
+	describe("Instances Creation", function () {
+
+		it("Construct", function () {
+
+			class Test {
+
+				constructed : boolean = false;
+
+				constructor() {
+					this.constructed = true;
+				}
+
+			}
+
+			const json = {};
+			const instance = Deserialize(json, Test, null, Instances.Construct);
+			expect(instance).toEqual({
+				constructed: true
+			});
+
+		});
+
+		it("Create", function () {
+
+			class Test {
+
+				constructed : boolean;
+
+				constructor() {
+					this.constructed = true;
+				}
+
+			}
+
+			const json = {};
+			const instance = Deserialize(json, Test, null, Instances.Create);
+			expect(instance.constructed).toBeUndefined();
+
+		});
+
+		it("Plain", function () {
+
+			class Test {
+			}
+
+			const json = {};
+			const instance = Deserialize(json, Test, null, Instances.Plain);
+			expect(typeof instance).toEqual('object');
+			expect(instance instanceof Test).toEqual(false);
+		});
+
+	});
+
 });

--- a/src/deserialize.ts
+++ b/src/deserialize.ts
@@ -1,10 +1,10 @@
 import {
   getTarget, Indexable, isPrimitiveType, JsonArray, JsonObject, JsonType, SerializablePrimitiveType,
-  SerializableType, Instances
+  SerializableType, InstantiationMethod
 } from "./util";
 import { MetaData, MetaDataFlag } from "./meta_data";
 
-export function DeserializeMap<T>(data : JsonObject, type : SerializableType<T>, target? : Indexable<T>, createInstances : Instances = Instances.Construct) : Indexable<T> {
+export function DeserializeMap<T>(data : JsonObject, type : SerializableType<T>, target? : Indexable<T>, createInstances : InstantiationMethod = InstantiationMethod.New) : Indexable<T> {
 
   if (typeof data !== "object") {
     throw new Error("Expected input to be of type `object` but received: " + typeof data);
@@ -28,7 +28,7 @@ export function DeserializeMap<T>(data : JsonObject, type : SerializableType<T>,
   return target;
 }
 
-export function DeserializeArray<T>(data : JsonArray, type : SerializableType<T>, target? : Array<T>, createInstances : Instances = Instances.Construct) {
+export function DeserializeArray<T>(data : JsonArray, type : SerializableType<T>, target? : Array<T>, createInstances : InstantiationMethod = InstantiationMethod.New) {
 
   if (!Array.isArray(data)) {
     throw new Error("Expected input to be an array but received: " + typeof data);
@@ -108,7 +108,7 @@ export function DeserializeJSON<T extends JsonType>(data : JsonType, transformKe
   return data;
 }
 
-export function Deserialize<T extends Indexable>(data : JsonObject, type : SerializableType<T>, target? : T, createInstances : Instances = Instances.Construct) : T | null {
+export function Deserialize<T extends Indexable>(data : JsonObject, type : SerializableType<T>, target? : T, createInstances : InstantiationMethod = InstantiationMethod.New) : T | null {
 
   const metadataList = MetaData.getMetaDataForType(type);
 
@@ -119,10 +119,10 @@ export function Deserialize<T extends Indexable>(data : JsonObject, type : Seria
       }
 
       switch (createInstances) {
-        case Instances.Construct:
+        case InstantiationMethod.New:
           return new type();
 
-        case Instances.Create:
+        case InstantiationMethod.ObjectCreate:
           return Object.create(type.prototype);
 
         default:
@@ -177,13 +177,13 @@ export function Deserialize<T extends Indexable>(data : JsonObject, type : Seria
 }
 
 export function DeserializeRaw<T>(data : JsonObject, type : SerializableType<T>, target? : T) : T | null {
-  return Deserialize(data, type, target, Instances.Plain);
+  return Deserialize(data, type, target, InstantiationMethod.None);
 }
 
 export function DeserializeArrayRaw<T>(data : JsonArray, type : SerializableType<T>, target? : Array<T>) : Array<T> | null {
-  return DeserializeArray(data, type, target, Instances.Plain);
+  return DeserializeArray(data, type, target, InstantiationMethod.None);
 }
 
 export function DeserializeMapRaw<T>(data : Indexable<JsonType>, type : SerializableType<T>, target? : Indexable<T>) : Indexable<T> | null {
-  return DeserializeMap(data, type, target, Instances.Plain);
+  return DeserializeMap(data, type, target, InstantiationMethod.None);
 }

--- a/src/deserialize.ts
+++ b/src/deserialize.ts
@@ -17,7 +17,7 @@ export function DeserializeMap<T>(data : JsonObject, type : SerializableType<T>,
   }
 
   const keys = Object.keys(data);
-  for (var i = 0; i < keys.length; i++) {
+  for (let i = 0; i < keys.length; i++) {
     const key = keys[i];
     const value = data[key];
     if (value !== void 0) {
@@ -37,7 +37,7 @@ export function DeserializeArray<T>(data : JsonArray, type : SerializableType<T>
   if (!Array.isArray(target)) target = [] as Array<T>;
 
   target.length = data.length;
-  for (var i = 0; i < data.length; i++) {
+  for (let i = 0; i < data.length; i++) {
     target[i] = Deserialize(data[i] as any, type, target[i], createInstances) as T;
   }
 
@@ -77,7 +77,7 @@ export function DeserializeJSON<T extends JsonType>(data : JsonType, transformKe
 
     (target as Array<JsonType>).length = data.length;
 
-    for (var i = 0; i < data.length; i++) {
+    for (let i = 0; i < data.length; i++) {
       (target as Array<JsonType>)[i] = DeserializeJSON(data[i], transformKeys, (target as Array<JsonType>)[i]);
     }
 
@@ -90,7 +90,7 @@ export function DeserializeJSON<T extends JsonType>(data : JsonType, transformKe
 
     const retn = (target && typeof target === "object" ? target : {}) as Indexable<JsonType>;
     const keys = Object.keys(data as object);
-    for (var i = 0; i < keys.length; i++) {
+    for (let i = 0; i < keys.length; i++) {
       const key = keys[i];
       const value = (data as Indexable<JsonType>)[key];
       if(value !== void 0) {
@@ -135,7 +135,7 @@ export function Deserialize<T extends Indexable>(data : JsonObject, type : Seria
 
   target = getTarget(type as any, target, createInstances) as T;
 
-  for (var i = 0; i < metadataList.length; i++) {
+  for (let i = 0; i < metadataList.length; i++) {
     const metadata = metadataList[i];
 
     if (metadata.deserializedKey === null) continue;

--- a/src/deserialize.ts
+++ b/src/deserialize.ts
@@ -4,7 +4,8 @@ import {
 } from "./util";
 import { MetaData, MetaDataFlag } from "./meta_data";
 
-export function DeserializeMap<T>(data : JsonObject, type : SerializableType<T>, target? : Indexable<T>, instantiationMethod : InstantiationMethod = InstantiationMethod.New) : Indexable<T> {
+export function DeserializeMap<T>(data : JsonObject, type : SerializableType<T>, target? : Indexable<T>, instantiationMethod? : InstantiationMethod) : Indexable<T> {
+  if (instantiationMethod === void 0) instantiationMethod = MetaData.deserializeInstantationMethod;
 
   if (typeof data !== "object") {
     throw new Error("Expected input to be of type `object` but received: " + typeof data);
@@ -28,7 +29,8 @@ export function DeserializeMap<T>(data : JsonObject, type : SerializableType<T>,
   return target;
 }
 
-export function DeserializeArray<T>(data : JsonArray, type : SerializableType<T>, target? : Array<T>, instantiationMethod : InstantiationMethod = InstantiationMethod.New) {
+export function DeserializeArray<T>(data : JsonArray, type : SerializableType<T>, target? : Array<T>, instantiationMethod? : InstantiationMethod) {
+  if (instantiationMethod === void 0) instantiationMethod = MetaData.deserializeInstantationMethod;
 
   if (!Array.isArray(data)) {
     throw new Error("Expected input to be an array but received: " + typeof data);
@@ -108,8 +110,8 @@ export function DeserializeJSON<T extends JsonType>(data : JsonType, transformKe
   return data;
 }
 
-export function Deserialize<T extends Indexable>(data : JsonObject, type : SerializableType<T>, target? : T, instantiationMethod : InstantiationMethod = InstantiationMethod.New) : T | null {
-
+export function Deserialize<T extends Indexable>(data : JsonObject, type : SerializableType<T>, target? : T, instantiationMethod? : InstantiationMethod) : T | null {
+  if (instantiationMethod === void 0) instantiationMethod = MetaData.deserializeInstantationMethod;
   const metadataList = MetaData.getMetaDataForType(type);
 
   if (metadataList === null) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export * from "./serialize";
 export * from "./deserialize";
 export * from "./annotations";
 export * from "./string_transforms";
+export {Instances} from './util';
 
 export function SetSerializeKeyTransform(fn : (str : string) => string) : void {
   if(typeof fn === "function") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,11 @@
 import { MetaData } from "./meta_data";
 import { NoOp } from "./string_transforms";
 
-export * from "./serialize";
-export * from "./deserialize";
-export * from "./annotations";
-export * from "./string_transforms";
-export {Instances} from './util';
+export *                     from "./serialize";
+export *                     from "./deserialize";
+export *                     from "./annotations";
+export *                     from "./string_transforms";
+export {InstantiationMethod} from './util';
 
 export function SetSerializeKeyTransform(fn : (str : string) => string) : void {
   if(typeof fn === "function") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
-import { MetaData } from "./meta_data";
-import { NoOp } from "./string_transforms";
+import { MetaData }          from "./meta_data";
+import { NoOp }              from "./string_transforms";
+import {InstantiationMethod} from "./util";
 
 export *                     from "./serialize";
 export *                     from "./deserialize";
@@ -22,5 +23,13 @@ export function SetDeserializeKeyTransform(fn : (str : string) => string) : void
   }
   else {
     MetaData.deserializeKeyTransform = NoOp;
+  }
+}
+
+export function SetDefaultInstantiationMethod(instantiationMethod : InstantiationMethod) : void {
+  if (instantiationMethod === null) {
+    MetaData.deserializeInstantationMethod = InstantiationMethod.New;
+  } else {
+    MetaData.deserializeInstantationMethod = instantiationMethod;
   }
 }

--- a/src/meta_data.ts
+++ b/src/meta_data.ts
@@ -2,7 +2,7 @@
 //in a type tagged with a serialization annotation will contain an array of these
 //objects each describing one property
 
-import { IConstructable, SerializableType } from "./util";
+import { IConstructable, SerializableType, InstantiationMethod } from "./util";
 import { NoOp } from "./string_transforms";
 
 const TypeMap = new Map<any, Array<MetaData>>();
@@ -125,5 +125,7 @@ export class MetaData {
   public static serializeKeyTransform = NoOp;
 
   public static deserializeKeyTransform = NoOp;
+
+  public static deserializeInstantationMethod = InstantiationMethod.New;
 
 }

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -5,7 +5,7 @@ export function SerializeMap<T>(source : T, type : SerializableType<T>) : Indexa
     const target : Indexable<JsonType> = {};
     const keys = Object.keys(source);
 
-    for (var i = 0; i < keys.length; i++) {
+    for (let i = 0; i < keys.length; i++) {
         const key = keys[i];
         const value = (source as any)[key];
         if(value !== void 0) {
@@ -18,7 +18,7 @@ export function SerializeMap<T>(source : T, type : SerializableType<T>) : Indexa
 
 export function SerializeArray<T>(source : Array<T>, type : SerializableType<T>) : Array<JsonType> {
     const retn = new Array<JsonType>(source.length);
-    for (var i = 0; i < source.length; i++) {
+    for (let i = 0; i < source.length; i++) {
         retn[i] = Serialize(source[i], type);
     }
     return retn;
@@ -53,7 +53,7 @@ export function SerializeJSON(source : any, transformKeys = true) : JsonType {
 
     if (Array.isArray(source)) {
         const array = new Array<any>(source.length);
-        for (var i = 0; i < source.length; i++) {
+        for (let i = 0; i < source.length; i++) {
             array[i] = SerializeJSON(source[i], transformKeys);
         }
         return array;
@@ -69,7 +69,7 @@ export function SerializeJSON(source : any, transformKeys = true) : JsonType {
         else {
             const retn : Indexable<JsonType> = {};
             const keys = Object.keys(source);
-            for (var i = 0; i < keys.length; i++) {
+            for (let i = 0; i < keys.length; i++) {
                 const key = keys[i];
                 const value = source[key];
                 if(value !== void 0) {
@@ -108,7 +108,7 @@ export function Serialize<T>(instance : T, type : SerializableType<T>) : JsonObj
 
     const target : Indexable<JsonType> = {};
 
-    for (var i = 0; i < metadataList.length; i++) {
+    for (let i = 0; i < metadataList.length; i++) {
         const metadata = metadataList[i];
 
         if (metadata.serializedKey === null) continue;

--- a/src/string_transforms.ts
+++ b/src/string_transforms.ts
@@ -3,9 +3,15 @@ export function NoOp(str : string) : string {
   return str;
 }
 
+//regexes
+const STRING_CAMELIZE_REGEXP = (/(-|_|\.|\s)+(.)?/g);
+const STRING_DECAMELIZE_REGEXP = (/([a-z\d])([A-Z])/g);
+const STRING_UNDERSCORE_REGEXP_1 = (/([a-z\d])([A-Z]+)/g);
+const STRING_UNDERSCORE_REGEXP_2 = (/-|\s+/g);
+const STRING_DASHERIZE_REGEXP = (/([a-z\d])([A-Z])/g);
+
 //convert strings like my_camel_string to myCamelString
 export function CamelCase(str : string) : string {
-  var STRING_CAMELIZE_REGEXP = (/(-|_|\.|\s)+(.)?/g);
   return str.replace(STRING_CAMELIZE_REGEXP, function (match, separator, chr) : string {
     return chr ? chr.toUpperCase() : '';
   }).replace(/^([A-Z])/, function (match, separator, chr) : string {
@@ -15,20 +21,16 @@ export function CamelCase(str : string) : string {
 
 //convert strings like MyCamelString to my_camel_string
 export function SnakeCase(str : string) : string {
-  var STRING_DECAMELIZE_REGEXP = (/([a-z\d])([A-Z])/g);
   return str.replace(STRING_DECAMELIZE_REGEXP, '$1_$2').toLowerCase();
 }
 
 //convert strings like myCamelCase to my_camel_case
 export function UnderscoreCase(str : string) : string {
-  var STRING_UNDERSCORE_REGEXP_1 = (/([a-z\d])([A-Z]+)/g);
-  var STRING_UNDERSCORE_REGEXP_2 = (/-|\s+/g);
   return str.replace(STRING_UNDERSCORE_REGEXP_1, '$1_$2').replace(STRING_UNDERSCORE_REGEXP_2, '_').toLowerCase();
 }
 
 //convert strings like my_camelCase to my-camel-case
 export function DashCase(str : string) : string {
-  var STRING_DASHERIZE_REGEXP = (/([a-z\d])([A-Z])/g);
   str = str.replace(/_/g, '-');
   return str.replace(STRING_DASHERIZE_REGEXP, '$1-$2').toLowerCase();
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,6 @@
 export type JsonType = null | string | number | boolean | JsonObject | JsonArray;
 export type Serializer<T> = (target : T) => JsonType;
-export type Deserializer<T> = (data : JsonType, target? : T, createInstances? : boolean) => T;
+export type Deserializer<T> = (data : JsonType, target? : T, instantiationMethod? : boolean) => T;
 export type IConstructable = { constructor : Function };
 export type SerializeFn = <T>(data : T) => JsonType;
 export type SerializablePrimitiveType =
@@ -35,17 +35,17 @@ export interface SerializableType<T> {
     new (...args : any[]) : T;
 
     onSerialized? : (data : JsonObject, instance : T) => JsonObject|void;
-    onDeserialized? : (data : JsonObject, instance : T, createInstances? : InstantiationMethod) => T|void;
+    onDeserialized? : (data : JsonObject, instance : T, instantiationMethod? : InstantiationMethod) => T|void;
 }
 
 
 /** @internal */
-export function getTarget<T>(type : SerializableType<T>, target : T, createInstances : InstantiationMethod) : T {
+export function getTarget<T>(type : SerializableType<T>, target : T, instantiationMethod : InstantiationMethod) : T {
 
     if (target !== null && target !== void 0) return target;
 
     if (type !== null) {
-        switch (createInstances) {
+        switch (instantiationMethod) {
             case InstantiationMethod.New:
             	return new type();
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -10,10 +10,10 @@ export type SerializablePrimitiveType =
     RegExpConstructor |
     StringConstructor;
 
-export enum Instances {
-	Plain = 0,
-	Construct = 1,
-	Create = 2
+export enum InstantiationMethod {
+	None = 0,
+	New = 1,
+	ObjectCreate = 2
 }
 
 export interface JsonObject {
@@ -35,21 +35,21 @@ export interface SerializableType<T> {
     new (...args : any[]) : T;
 
     onSerialized? : (data : JsonObject, instance : T) => JsonObject|void;
-    onDeserialized? : (data : JsonObject, instance : T, createInstances? : Instances) => T|void;
+    onDeserialized? : (data : JsonObject, instance : T, createInstances? : InstantiationMethod) => T|void;
 }
 
 
 /** @internal */
-export function getTarget<T>(type : SerializableType<T>, target : T, createInstances : Instances) : T {
+export function getTarget<T>(type : SerializableType<T>, target : T, createInstances : InstantiationMethod) : T {
 
     if (target !== null && target !== void 0) return target;
 
     if (type !== null) {
         switch (createInstances) {
-            case Instances.Construct:
+            case InstantiationMethod.New:
             	return new type();
 
-			case Instances.Create:
+			case InstantiationMethod.ObjectCreate:
 				return Object.create(type.prototype);
         }
     }

--- a/src/util.ts
+++ b/src/util.ts
@@ -10,6 +10,11 @@ export type SerializablePrimitiveType =
     RegExpConstructor |
     StringConstructor;
 
+export enum Instances {
+	Plain = 0,
+	Construct = 1,
+	Create = 2
+}
 
 export interface JsonObject {
     [idx : string] : JsonType|JsonObject;
@@ -30,16 +35,23 @@ export interface SerializableType<T> {
     new (...args : any[]) : T;
 
     onSerialized? : (data : JsonObject, instance : T) => JsonObject|void;
-    onDeserialized? : (data : JsonObject, instance : T, createInstances? : boolean) => T|void;
+    onDeserialized? : (data : JsonObject, instance : T, createInstances? : Instances) => T|void;
 }
 
+
 /** @internal */
-export function getTarget<T>(type : SerializableType<T>, target : T, createInstances : boolean) : T {
+export function getTarget<T>(type : SerializableType<T>, target : T, createInstances : Instances) : T {
 
     if (target !== null && target !== void 0) return target;
 
-    if (type !== null && createInstances) {
-        return new type();
+    if (type !== null) {
+        switch (createInstances) {
+            case Instances.Construct:
+            	return new type();
+
+			case Instances.Create:
+				return Object.create(type.prototype);
+        }
     }
 
     return {} as T;

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,6 @@
 export type JsonType = null | string | number | boolean | JsonObject | JsonArray;
 export type Serializer<T> = (target : T) => JsonType;
-export type Deserializer<T> = (data : JsonType, target? : T, instantiationMethod? : boolean) => T;
+export type Deserializer<T> = (data : JsonType, target? : T, instantiationMethod? : InstantiationMethod) => T;
 export type IConstructable = { constructor : Function };
 export type SerializeFn = <T>(data : T) => JsonType;
 export type SerializablePrimitiveType =


### PR DESCRIPTION
This addresses issue #79 for the 2.0.0 release.

It **is an incompatible** change, but it *should* hopefully be fine since v2 isn't officially released or published yet.

The breaking change is replacing the type of `createInstances : boolean` variable to a new enum `Instances`. This enum represents hints at how the library should initialize object instances when they don't already exist. All tests and documentation have been updated to reflect this.

---

Before:

```typescript
Deserialize(json, MyClass, false); // Create plain objects.
Deserialize(json, MyClass, true);  // Create instance objects, calling the constructor.
```

After:

```typescript
import {Instances} from 'cerialize';
Deserialize(json, MyClass, Instances.Plain);     // Create plain objects.
Deserialize(json, MyClass, Instances.Construct); // Create instance objects, calling the constructor.
Deserialize(json, MyClass, Instances.Create);    // Create instance objects, do not call the constructor.
```
